### PR TITLE
feat: 添加考勤未知状态类型并调整颜色显示

### DIFF
--- a/app/AttendanceInterface.py
+++ b/app/AttendanceInterface.py
@@ -311,12 +311,14 @@ class AttendanceFlowWidget(QFrame):
             self.tableWidget.setItem(i, 0, QTableWidgetItem(record[i].water_time))
             self.tableWidget.setItem(i, 1, QTableWidgetItem(record[i].place))
             statusWidget = QTableWidgetItem(self.mapTypeToResult(record[i].type_))
-            if record[i].type_ == FlowRecordType.INVALID:
+            if record[i].type_ == FlowRecordType.VALID:
+                statusWidget.setForeground(Color.VALID_COLOR)
+            elif record[i].type_ == FlowRecordType.INVALID:
                 statusWidget.setForeground(Color.INVALID_COLOR)
             elif record[i].type_ == FlowRecordType.REPEATED:
                 statusWidget.setForeground(Color.REPEAT_COLOR)
             else:
-                statusWidget.setForeground(Color.VALID_COLOR)
+                statusWidget.setForeground(Color.UNKNOWN_COLOR)
             self.tableWidget.setItem(i, 2, statusWidget)
 
     def constructWithAccountFrame(self) -> QFrame:

--- a/app/utils/style_sheet.py
+++ b/app/utils/style_sheet.py
@@ -35,3 +35,4 @@ class Color:
     INVALID_COLOR = QColor(255, 0, 0)
     VALID_COLOR = QColor(0, 255, 0)
     REPEAT_COLOR = QColor(0, 0, 255)
+    UNKNOWN_COLOR = QColor(122, 122, 122)

--- a/attendance/attendance.py
+++ b/attendance/attendance.py
@@ -47,7 +47,11 @@ class AttendanceFlow:
 
     @classmethod
     def from_json(cls, json):
-        return cls(json["sBh"], json["eqno"], json["watertime"], FlowRecordType(int(json["isdone"])))
+        try:
+            type_ = FlowRecordType(int(json["isdone"]))
+        except ValueError:
+            type_ = FlowRecordType.UNKNOWN
+        return cls(json["sBh"], json["eqno"], json["watertime"], type_)
 
     def json(self):
         return {"sBh": self.sbh, "eqno": self.place, "watertime": self.water_time, "isdone": self.type_.value}

--- a/attendance/attendance.py
+++ b/attendance/attendance.py
@@ -16,6 +16,7 @@ class FlowRecordType(Enum):
     INVALID = 0  # 无效：指在某个教室没有课但刷了卡
     VALID = 1  # 有效：指在有课的教室成功刷卡
     REPEATED = 2  # 重复：在某个有课的教室多次刷卡
+    UNKNOWN = 9  # 未知：不清楚是什么情况
 
 
 class WaterType(Enum):


### PR DESCRIPTION
在 FlowRecordType 中新增 UNKNOWN(9) 类型，对应颜色 #7A7A7A，调整考勤流水界面的状态颜色逻辑：VALID 显示绿色，UNKNOWN 显示灰色，兜底改为灰色。