### PR TITLE
feat: 合并所有系统的 session、适配新的两步验证

### DIFF
--- a/app/main_window.py
+++ b/app/main_window.py
@@ -30,6 +30,7 @@ from .sessions.gste_session import GSTESession
 from .sessions.jwapp_session import JwappSession
 from .sessions.lms_session import LMSSession
 from .sub_interfaces import LoginInterface
+from .sub_interfaces.VerifyCodeDialog import VerifyCodeDialog
 from .sub_interfaces import AutoJudgeInterface
 from .sub_interfaces.EmptyRoomInterface import EmptyRoomInterface
 from app.LMSInterface import LMSInterface
@@ -37,7 +38,8 @@ from .sub_interfaces.NoticeInterface import NoticeInterface
 from .sub_interfaces.NoticeSettingInterface import NoticeSettingInterface
 from .sub_interfaces.WebVPNConvertInterface import WebVPNConvertInterface
 from .threads.UpdateThread import UpdateThread, UpdateStatus
-from .utils import cfg, accounts, MyFluentIcon, SessionManager, logger, migrate_all
+from .utils import cfg, accounts, MyFluentIcon, SessionManager, logger, migrate_all, QtMFAProvider, MFAAction, \
+    MFAActionType, MFARequest
 from .utils.config import TraySetting
 
 
@@ -77,6 +79,17 @@ class MainWindow(MSFluentWindow):
         super().__init__(parent)
 
         registerSession()
+        self.mfaProvider = QtMFAProvider(self)
+        # 线程要求 mfa 验证时，显示 MFA 对话框，并将用户的操作转交给 QtMFAProvider
+        self.mfaProvider.requestMFA.connect(self.show_mfa_dialog)
+        # 通过 QtMFAProvider 的 sendResult 信号收到验证码发送结果，在对话框中显示给用户  
+        self.mfaProvider.sendResult.connect(self.on_mfa_send_result)
+        # MFA 验证是要一个个来的，不能并行，因此这里都是单例
+        self._current_mfa_dialog: VerifyCodeDialog | None = None
+        self._current_mfa_request: MFARequest | None = None
+        # 为当前已知账户安装全局 MFA provider, 这样每个 session 都能找到它来处理 MFA 请求了
+        self._install_mfa_provider_for_accounts()
+        accounts.accountAdded.connect(self._install_mfa_provider_for_accounts)
 
         self.light_icon = QIcon("assets/icons/toolbox_light.png")
         self.dark_icon = QIcon("assets/icons/toolbox_dark.png")
@@ -139,7 +152,7 @@ class MainWindow(MSFluentWindow):
 
     def initInterface(self):
         self.home_interface = HomeInterface(self, self)
-        self.login_interface = LoginInterface(self)
+        self.login_interface = LoginInterface(self, mfa_provider=self.mfaProvider)
         self.attendance_interface = AttendanceInterface(self, self)
         self.account_interface = AccountInterface(accounts, self, self)
         self.setting_interface = SettingInterface(self, self)
@@ -170,6 +183,52 @@ class MainWindow(MSFluentWindow):
         self.tray_interface.notice_interface.connect(lambda: self.switchTo(self.notice_interface) or self.show())
         if cfg.traySetting.value == TraySetting.MINIMIZE:
             self.tray_interface.show()
+
+    def _install_mfa_provider_for_accounts(self) -> None:
+        """
+        为当前已知账户安装全局 MFA provider。
+        """
+        for account in accounts:
+            account.session_manager.set_mfa_provider(self.mfaProvider)
+
+    @pyqtSlot(object)
+    def show_mfa_dialog(self, request: object) -> None:
+        """
+        显示 MFA 对话框，并将用户动作转交给 QtMFAProvider。
+        """
+        if not isinstance(request, MFARequest):
+            return
+
+        dialog = VerifyCodeDialog(request, self)
+        self._current_mfa_dialog = dialog
+        self._current_mfa_request = request
+        # 用户点击发送验证码后，要求 mfaProvider 完成发送验证码的操作，并将结果通过 sendResult 信号反馈给对话框
+        dialog.sendSignal.connect(
+            lambda: self.mfaProvider.submit_action(MFAAction(MFAActionType.SEND_CODE))
+        )
+        # 用户在对话框中输入验证码并点击验证后，要求 mfaProvider 完成验证操作，并将用户输入的验证码和是否信任设备的选项一起提交
+        dialog.codeSignal.connect(
+            lambda code, trust: self.mfaProvider.submit_action(
+                MFAAction(MFAActionType.VERIFY_CODE, code=code, trust_agent=trust)
+            )
+        )
+        # 用户点击取消后，要求 mfaProvider 取消当前的 MFA 验证流程
+        dialog.cancelSignal.connect(
+            lambda: self.mfaProvider.submit_action(MFAAction(MFAActionType.CANCEL))
+        )
+        dialog.exec()
+        if self._current_mfa_dialog is dialog:
+            self._current_mfa_dialog = None
+            self._current_mfa_request = None
+
+    @pyqtSlot(object, bool, str)
+    def on_mfa_send_result(self, request: object, success: bool, message: str) -> None:
+        """
+        将验证码发送结果反馈给当前 MFA 对话框。
+        """
+        if request != self._current_mfa_request or self._current_mfa_dialog is None:
+            return
+        self._current_mfa_dialog.reportSendResult(success, message)
 
     def initNavigation(self):
         self.addSubInterface(self.home_interface, FIF.HOME, self.tr("主页"))

--- a/app/sessions/attendance_session.py
+++ b/app/sessions/attendance_session.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 import enum
 
 from app.sessions.common_session import CommonLoginSession
+from app.sessions.session_backend import AccessMode, SessionBackend
 from app.utils import cfg
 from attendance.attendance import AttendanceNewLogin, AttendanceNewWebVPNLogin
 from auth import WEBVPN_LOGIN_URL
@@ -11,16 +14,22 @@ class AttendanceSession(CommonLoginSession):
     """
     bkkq.xjtu.edu.cn 登录用的 Session
     """
+    site_key = "attendance"
+    supports_webvpn = True
+
     class LoginMethod(enum.Enum):
         NORMAL = 0
         WEBVPN = 1
 
-    def __init__(self, time=15*60):
-        super().__init__(time)
-        self.login_method = None
+    def __init__(self, backend: SessionBackend | None = None, webvpn_backend: SessionBackend | None = None,
+                 timeout: int = 15 * 60) -> None:
+        super().__init__(backend=backend, timeout=timeout)
+        self.normal_backend = self.backend
+        self.webvpn_backend = webvpn_backend or SessionBackend(AccessMode.WEBVPN, timeout=timeout)
 
-    def _login(self, username, password, *args, **kwargs):
-        is_postgraduate = kwargs.get("is_postgraduate", False)
+    def _login(self, username: str, password: str, **kwargs: object) -> None:
+        self.set_backend(self.normal_backend)
+        is_postgraduate = kwargs.get("is_postgraduate") is True
         login_util = AttendanceNewLogin(self, is_postgraduate=is_postgraduate, visitor_id=str(cfg.loginId.value))
         login_util.login_or_raise(username, password)
 
@@ -29,20 +38,28 @@ class AttendanceSession(CommonLoginSession):
         self.reset_timeout()
         self.has_login = True
 
-    def webvpn_login(self, username, password, is_postgraduate=False):
+    def webvpn_login(self, username: str, password: str, is_postgraduate: bool = False) -> None:
+        """通过 WebVPN 登录考勤系统。"""
         # 目前 WebVPN 访问分为两个步骤
         # 1. 登录 WebVPN 自身，此时采用不经过 WebVPN 中介的接口
         # 2. 登录 WebVPN 之后，再登录一次目标网站。此时采用经过 WebVPN 中介的接口
-        self.cookies.clear()
-        login_util = NewLogin(WEBVPN_LOGIN_URL, self, visitor_id=str(cfg.loginId.value))
-        login_util.login_or_raise(username, password)
+        with self.login_lock:
+            self.clear_site_state()
+            self.set_backend(self.webvpn_backend)
 
-        attendance_login_util = AttendanceNewWebVPNLogin(self, is_postgraduate=is_postgraduate, visitor_id=str(cfg.loginId.value))
-        attendance_login_util.login_or_raise(username, password)
+            with self.webvpn_backend.login_lock:
+                if not self.webvpn_backend.has_login:
+                    login_util = NewLogin(WEBVPN_LOGIN_URL, self, visitor_id=str(cfg.loginId.value))
+                    login_util.login_or_raise(username, password)
+                    self.webvpn_backend.has_login = True
 
-        self.login_method = self.LoginMethod.WEBVPN
+            attendance_login_util = AttendanceNewWebVPNLogin(self, is_postgraduate=is_postgraduate,
+                                                             visitor_id=str(cfg.loginId.value))
+            attendance_login_util.login_or_raise(username, password)
 
-        self.reset_timeout()
-        self.has_login = True
+            self.login_method = self.LoginMethod.WEBVPN
+
+            self.reset_timeout()
+            self.has_login = True
 
     _re_login = _login

--- a/app/sessions/attendance_session.py
+++ b/app/sessions/attendance_session.py
@@ -5,6 +5,7 @@ import enum
 from app.sessions.common_session import CommonLoginSession
 from app.sessions.session_backend import AccessMode, SessionBackend
 from app.utils import cfg
+from app.utils.interactive_login import login_with_optional_mfa
 from attendance.attendance import AttendanceNewLogin, AttendanceNewWebVPNLogin
 from auth import WEBVPN_LOGIN_URL
 from auth.new_login import NewLogin
@@ -15,6 +16,7 @@ class AttendanceSession(CommonLoginSession):
     bkkq.xjtu.edu.cn 登录用的 Session
     """
     site_key = "attendance"
+    site_name = "考勤系统"
     supports_webvpn = True
 
     class LoginMethod(enum.Enum):
@@ -31,14 +33,25 @@ class AttendanceSession(CommonLoginSession):
         self.set_backend(self.normal_backend)
         is_postgraduate = kwargs.get("is_postgraduate") is True
         login_util = AttendanceNewLogin(self, is_postgraduate=is_postgraduate, visitor_id=str(cfg.loginId.value))
-        login_util.login_or_raise(username, password)
+        account, mfa_provider = self.get_login_context(kwargs)
+        account_type = NewLogin.POSTGRADUATE if is_postgraduate else NewLogin.UNDERGRADUATE
+        login_with_optional_mfa(
+            login_util,
+            username,
+            password,
+            account,
+            mfa_provider,
+            account_type=account_type,
+            site_key=self.site_key,
+            site_name=self.site_name,
+        )
 
         self.login_method = self.LoginMethod.NORMAL
 
         self.reset_timeout()
         self.has_login = True
 
-    def webvpn_login(self, username: str, password: str, is_postgraduate: bool = False) -> None:
+    def webvpn_login(self, username: str, password: str, is_postgraduate: bool = False, **kwargs: object) -> None:
         """通过 WebVPN 登录考勤系统。"""
         # 目前 WebVPN 访问分为两个步骤
         # 1. 登录 WebVPN 自身，此时采用不经过 WebVPN 中介的接口
@@ -46,16 +59,36 @@ class AttendanceSession(CommonLoginSession):
         with self.login_lock:
             self.clear_site_state()
             self.set_backend(self.webvpn_backend)
+            account, mfa_provider = self.get_login_context(kwargs)
+            account_type = NewLogin.POSTGRADUATE if is_postgraduate else NewLogin.UNDERGRADUATE
 
             with self.webvpn_backend.login_lock:
                 if not self.webvpn_backend.has_login:
                     login_util = NewLogin(WEBVPN_LOGIN_URL, self, visitor_id=str(cfg.loginId.value))
-                    login_util.login_or_raise(username, password)
+                    login_with_optional_mfa(
+                        login_util,
+                        username,
+                        password,
+                        account,
+                        mfa_provider,
+                        account_type=account_type,
+                        site_key="webvpn",
+                        site_name="WebVPN",
+                    )
                     self.webvpn_backend.has_login = True
 
             attendance_login_util = AttendanceNewWebVPNLogin(self, is_postgraduate=is_postgraduate,
                                                              visitor_id=str(cfg.loginId.value))
-            attendance_login_util.login_or_raise(username, password)
+            login_with_optional_mfa(
+                attendance_login_util,
+                username,
+                password,
+                account,
+                mfa_provider,
+                account_type=account_type,
+                site_key=self.site_key,
+                site_name=self.site_name,
+            )
 
             self.login_method = self.LoginMethod.WEBVPN
 

--- a/app/sessions/attendance_session.py
+++ b/app/sessions/attendance_session.py
@@ -7,7 +7,7 @@ from app.sessions.session_backend import AccessMode, SessionBackend
 from app.utils import cfg
 from app.utils.interactive_login import login_with_optional_mfa
 from attendance.attendance import AttendanceNewLogin, AttendanceNewWebVPNLogin
-from auth import WEBVPN_LOGIN_URL
+from auth import WEBVPN_LOGIN_URL, getVPNUrl
 from auth.new_login import NewLogin
 
 
@@ -63,6 +63,8 @@ class AttendanceSession(CommonLoginSession):
             account_type = NewLogin.POSTGRADUATE if is_postgraduate else NewLogin.UNDERGRADUATE
 
             with self.webvpn_backend.login_lock:
+                if self.webvpn_backend.has_timeout():
+                    self.webvpn_backend.has_login = False
                 if not self.webvpn_backend.has_login:
                     login_util = NewLogin(WEBVPN_LOGIN_URL, self, visitor_id=str(cfg.loginId.value))
                     login_with_optional_mfa(
@@ -96,3 +98,28 @@ class AttendanceSession(CommonLoginSession):
             self.has_login = True
 
     _re_login = _login
+
+    def validate_login(self) -> bool:
+        """通过考勤系统学生信息接口验证站点登录态。"""
+        if "Synjones-Auth" not in self.headers:
+            return False
+
+        is_postgraduate = False
+        if self._login_context is not None:
+            is_postgraduate = self._login_context.kwargs.get("is_postgraduate") is True
+
+        domain = "yjskq.xjtu.edu.cn" if is_postgraduate else "bkkq.xjtu.edu.cn"
+        url = f"https://{domain}/attendance-student/global/getStuInfo"
+        if self.login_method == self.LoginMethod.WEBVPN:
+            url = getVPNUrl(url)
+
+        response = self.post(url, timeout=10, _skip_auth_check=True)
+        if not response.ok or self.is_auth_failure_response(response):
+            return False
+
+        try:
+            result = response.json()
+        except ValueError:
+            return False
+
+        return result.get("success") is True

--- a/app/sessions/common_session.py
+++ b/app/sessions/common_session.py
@@ -4,11 +4,16 @@ import threading
 import time
 from abc import ABCMeta, abstractmethod
 from collections.abc import Mapping
+from typing import TYPE_CHECKING, cast
 
 import requests
 import requests.structures
 
 from .session_backend import AccessMode, SessionBackend
+
+if TYPE_CHECKING:
+    from app.utils.account import Account
+    from app.utils.mfa import MFAProvider
 
 
 class CommonLoginSession(metaclass=ABCMeta):
@@ -19,6 +24,8 @@ class CommonLoginSession(metaclass=ABCMeta):
     """
     # 当前站点的标识符号。子类应当重写这个变量
     site_key = ""
+    # 当前站点展示给用户的名称。子类可以重写这个变量
+    site_name = ""
     # 站点默认选择的访问方式（是否通过 WebVPN 访问）
     default_access_mode = AccessMode.NORMAL
     # 当前站点是否支持 WebVPN。子类应当重写这个变量
@@ -148,6 +155,20 @@ class CommonLoginSession(metaclass=ABCMeta):
         """清理当前访问方式共享后端的全部 cookie。"""
         self.backend.clear_cookies()
         self.clear_site_state()
+
+    def get_login_context(self, kwargs: dict[str, object]) -> tuple[Account | None, MFAProvider | None]:
+        """
+        从登录参数中提取账号和 MFA provider 上下文。
+        """
+        from app.utils.account import Account
+
+        account_value = kwargs.get("account")
+        account = account_value if isinstance(account_value, Account) else None
+        provider_value = kwargs.get("mfa_provider")
+        provider = cast("MFAProvider | None", provider_value)
+        if provider is None and account is not None:
+            provider = account.session_manager.mfa_provider
+        return account, provider
 
     def close(self) -> None:
         """关闭当前适配器使用的共享后端。"""

--- a/app/sessions/common_session.py
+++ b/app/sessions/common_session.py
@@ -4,16 +4,29 @@ import threading
 import time
 from abc import ABCMeta, abstractmethod
 from collections.abc import Mapping
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, cast
 
 import requests
 import requests.structures
 
+from auth import ServerError, is_safety_verify_page
 from .session_backend import AccessMode, SessionBackend
 
 if TYPE_CHECKING:
     from app.utils.account import Account
     from app.utils.mfa import MFAProvider
+
+
+@dataclass(frozen=True)
+class LoginContext:
+    """
+    记录最近一次登录使用的账号上下文，用于登录态失效后的原地恢复。
+    """
+    username: str
+    password: str
+    account_uuid: str | None
+    kwargs: Mapping[str, object]
 
 
 class CommonLoginSession(metaclass=ABCMeta):
@@ -48,6 +61,8 @@ class CommonLoginSession(metaclass=ABCMeta):
         # 是否已经登录
         self._has_login = False
         self.login_method = None
+        self._login_context: LoginContext | None = None
+        self._login_depth = 0
         # 自身防止同时登录的锁
         self.login_lock = threading.RLock()
 
@@ -71,8 +86,10 @@ class CommonLoginSession(metaclass=ABCMeta):
         因此需要额外的标识位。
         如果当前已经超时，那么查询 has_login 时，has_login 会变为 False。
         """
-        if self.has_timeout():
+        if self.has_timeout() or self.backend.has_timeout():
             self._has_login = False
+            if self.backend.has_timeout():
+                self.backend.has_login = False
         return self._has_login
 
     @has_login.setter
@@ -89,8 +106,28 @@ class CommonLoginSession(metaclass=ABCMeta):
         登录指定的网站。
         """
         with self.login_lock:
+            self._remember_login_context(username, password, kwargs)
             self.clear_site_state()
-            self._login(username, password, **kwargs)
+            self._run_login(username, password, **kwargs)
+
+    def ensure_login(self, username: str, password: str, force: bool = False, **kwargs: object) -> bool:
+        """
+        确保当前业务站点已经具有可用登录态。
+
+        :param username: 登录用户名
+        :param password: 登录密码
+        :param force: 是否跳过现有状态并强制重新登录
+        :param kwargs: 传递给具体登录实现的上下文参数
+        :return: 如果本次执行了登录流程则返回 True，否则返回 False
+        """
+        with self.login_lock:
+            self._remember_login_context(username, password, kwargs)
+            if not force and self.has_login and self.validate_login():
+                return False
+
+            self.invalidate_login()
+            self._run_login(username, password, **kwargs)
+            return True
 
     @abstractmethod
     def _login(self, username: str, password: str, **kwargs: object) -> None:
@@ -103,8 +140,9 @@ class CommonLoginSession(metaclass=ABCMeta):
         重新登录指定的网站。
         """
         with self.login_lock:
+            self._remember_login_context(username, password, kwargs)
             self.clear_site_state()
-            self._re_login(username, password, **kwargs)
+            self._run_re_login(username, password, **kwargs)
 
     @abstractmethod
     def _re_login(self, username: str, password: str, **kwargs: object) -> None:
@@ -120,6 +158,7 @@ class CommonLoginSession(metaclass=ABCMeta):
         self.backend.reset_timeout()
 
         request_headers = kwargs.pop("headers", None)
+        skip_auth_check = kwargs.pop("_skip_auth_check", False) is True
         headers: dict[str, str] = {}
         # 使用公用 headers
         headers.update(self.backend.session.headers)
@@ -131,7 +170,12 @@ class CommonLoginSession(metaclass=ABCMeta):
             for key, value in request_headers.items():
                 headers[str(key)] = str(value)
 
-        return self.backend.session.request(method, url, headers=headers, **kwargs)
+        response = self.backend.session.request(method, url, headers=headers, **kwargs)
+        if skip_auth_check or self._login_depth > 0 or not self.is_auth_failure_response(response):
+            return response
+
+        self.invalidate_login()
+        return self._retry_request_after_auth_failure(method, url, request_headers, kwargs)
 
     def get(self, url: str, **kwargs: object) -> requests.Response:
         """发起 GET 请求。"""
@@ -151,6 +195,17 @@ class CommonLoginSession(metaclass=ABCMeta):
         self.headers.clear()
         self.login_method = None
 
+    def invalidate_login(self) -> None:
+        """标记当前业务站点登录态已经失效，并清理站点专属状态。"""
+        self.clear_site_state()
+
+    def validate_login(self) -> bool:
+        """
+        验证当前业务站点登录态是否仍然可信。
+        子类可以重写该方法，通过访问学校系统需要权限的接口实测是否要重新登录。
+        """
+        return self.has_login
+
     def clear_backend_cookies(self) -> None:
         """清理当前访问方式共享后端的全部 cookie。"""
         self.backend.clear_cookies()
@@ -169,6 +224,116 @@ class CommonLoginSession(metaclass=ABCMeta):
         if provider is None and account is not None:
             provider = account.session_manager.mfa_provider
         return account, provider
+
+    def is_auth_failure_response(self, response: requests.Response) -> bool:
+        """
+        判断一个响应是否表示当前业务站点登录态已经失效。
+        判断标准：
+        1. 响应的 Content-Type 不是 HTML 或纯文本，且响应内容不以 "<" 开头（排除接口返回的 JSON 等非 HTML 内容）；
+        2. 响应内容是安全验证页或统一身份认证登录页。
+        子类可以考虑使用该方法辅助重写 validate_login 方法。
+        """
+        content_type = response.headers.get("Content-Type", "").lower()
+        if "html" not in content_type and "text" not in content_type:
+            stripped_text = response.text.lstrip()
+            if not stripped_text.startswith("<"):
+                return False
+
+        page = response.text
+        return is_safety_verify_page(page) or self._is_unified_login_page(page)
+
+    def _remember_login_context(self, username: str, password: str, kwargs: Mapping[str, object]) -> None:
+        """保存最近一次登录上下文，供响应兜底恢复使用。"""
+        self._login_context = LoginContext(
+            username=username,
+            password=password,
+            account_uuid=self._extract_account_uuid(kwargs),
+            kwargs=dict(kwargs),
+        )
+
+    def _extract_account_uuid(self, kwargs: Mapping[str, object]) -> str | None:
+        """从登录参数中提取账号 UUID。"""
+        from app.utils.account import Account
+
+        account_value = kwargs.get("account")
+        if isinstance(account_value, Account):
+            return account_value.uuid
+        return None
+
+    def _current_account_uuid(self) -> str | None:
+        """返回应用当前选中账号的 UUID。"""
+        from app.utils.account import accounts
+
+        if accounts.current is None:
+            return None
+        return accounts.current.uuid
+
+    def _ensure_login_context_matches_current_account(self, context: LoginContext) -> None:
+        """确认自动重登上下文仍属于当前选中账号。"""
+        current_account_uuid = self._current_account_uuid()
+        if context.account_uuid is None or current_account_uuid is None:
+            return
+        if context.account_uuid == current_account_uuid:
+            return
+
+        self.invalidate_login()
+        raise ServerError(102, "当前业务系统登录态属于此前选中的账号，请重新登录当前账号。")
+
+    def _is_unified_login_page(self, html_content: str) -> bool:
+        """判断响应是否为统一身份认证登录页。"""
+        has_login_form = 'id="fm1"' in html_content and 'name="execution"' in html_content
+        has_login_marker = (
+            "login.xjtu.edu.cn" in html_content
+            or "cas/login" in html_content
+            or "统一身份认证" in html_content
+        )
+        return has_login_form and has_login_marker
+
+    def _run_login(self, username: str, password: str, **kwargs: object) -> None:
+        """在登录保护区内执行具体登录实现。"""
+        self._login_depth += 1
+        try:
+            self._login(username, password, **kwargs)
+        finally:
+            self._login_depth -= 1
+
+    def _run_re_login(self, username: str, password: str, **kwargs: object) -> None:
+        """在登录保护区内执行具体重新登录实现。"""
+        self._login_depth += 1
+        try:
+            self._re_login(username, password, **kwargs)
+        finally:
+            self._login_depth -= 1
+
+    def _retry_request_after_auth_failure(
+            self,
+            method: str,
+            url: str,
+            request_headers: object,
+            request_kwargs: dict[str, object]) -> requests.Response:
+        """
+        在业务请求遇到二次认证页后，尝试重新登录并重放本次请求。
+        """
+        if self._login_context is None:
+            raise ServerError(102, "当前业务系统登录态已失效，需要重新登录。")
+
+        context = self._login_context
+        # 确保缓存的账号和当前登录的账户一致，以免误用之前账号的登录态
+        # 这一般不会有问题，因为 SessionManager 是每个账户都有一个的，因此每个账户都各自持有每种 session
+        # 理论上不会出现登录态被误用到其他账号的情况，但这里多加一个检查以防万一
+        self._ensure_login_context_matches_current_account(context)
+        # 尝试重新使用 context 静默登录
+        self.ensure_login(context.username, context.password, force=True, **dict(context.kwargs))
+
+        retry_kwargs = dict(request_kwargs)
+        if request_headers is not None:
+            retry_kwargs["headers"] = request_headers
+        retry_kwargs["_skip_auth_check"] = True
+        retry_response = self.request(method, url, **retry_kwargs)
+        if self.is_auth_failure_response(retry_response):
+            self.invalidate_login()
+            raise ServerError(102, "当前业务系统登录态已失效，需要重新进行安全验证。")
+        return retry_response
 
     def close(self) -> None:
         """关闭当前适配器使用的共享后端。"""

--- a/app/sessions/common_session.py
+++ b/app/sessions/common_session.py
@@ -1,34 +1,61 @@
+from __future__ import annotations
+
+import threading
 import time
-from abc import abstractmethod, ABCMeta
+from abc import ABCMeta, abstractmethod
+from collections.abc import Mapping
 
 import requests
+import requests.structures
 
-from ..utils import cfg
+from .session_backend import AccessMode, SessionBackend
 
 
-class CommonLoginSession(requests.Session, metaclass=ABCMeta):
+class CommonLoginSession(metaclass=ABCMeta):
     """
     需要登录的所有网站的 Session 基类，具有登录/重新登录的接口。
     由于会出现无限递归，此类自身不支持自动重新登录，需要外界检查 has_timeout 接口并手动调用登录。
     在本程序的其他模块，统一使用 session 提供的方法登录，没有具体的进度提示。
     """
-    def __init__(self, timeout=15*60):
+    # 当前站点的标识符号。子类应当重写这个变量
+    site_key = ""
+    # 站点默认选择的访问方式（是否通过 WebVPN 访问）
+    default_access_mode = AccessMode.NORMAL
+    # 当前站点是否支持 WebVPN。子类应当重写这个变量
+    supports_webvpn = False
+
+    def __init__(self, backend: SessionBackend | None = None, site_key: str | None = None,
+                 timeout: int = 15 * 60) -> None:
         """
         初始化一个登录 session
         :param timeout: 在多长时间不发送网络请求后，需要重新登录。
         """
-        super().__init__()
-        # 设置 UA
-        self.headers.update({"User-Agent": cfg.userAgent.value})
+        self.backend = backend or SessionBackend(self.default_access_mode, timeout=timeout)
+        self.site_key = site_key or self.site_key or self.__class__.__name__
+        # 站点专用 headers。底层 UA 等共享 headers 保存在 backend.session.headers 中。
+        self.headers = requests.structures.CaseInsensitiveDict()
         # 超时时间
         self._timeout = timeout
         # 上次发送请求的时间
-        self._last_request_time = 0
+        self._last_request_time = 0.0
         # 是否已经登录
         self._has_login = False
+        self.login_method = None
+        # 自身防止同时登录的锁
+        self.login_lock = threading.RLock()
 
     @property
-    def has_login(self):
+    def access_mode(self) -> AccessMode:
+        """返回当前适配器正在使用的访问方式。"""
+        return self.backend.access_mode
+
+    @property
+    def cookies(self) -> requests.cookies.RequestsCookieJar:
+        """返回当前访问方式共享的 cookie jar。"""
+        return self.backend.session.cookies
+
+    @property
+    def has_login(self) -> bool:
         """
         当前 session 是否已经登录。此属性默认为 False，需要手动设置为 True.
         当前 session 超时后，此属性会被自动设置为 False.
@@ -42,56 +69,97 @@ class CommonLoginSession(requests.Session, metaclass=ABCMeta):
         return self._has_login
 
     @has_login.setter
-    def has_login(self, value):
+    def has_login(self, value: bool) -> None:
         if not isinstance(value, bool):
             raise ValueError("has_login should be bool ")
 
         self._has_login = value
+        if value:
+            self.backend.has_login = True
 
-    def login(self, username, password, *args, **kwargs):
+    def login(self, username: str, password: str, **kwargs: object) -> None:
         """
-        登录。此方法应当被重载，实现登录的操作。
+        登录指定的网站。
         """
-        # 必须清除目前已有的 cookies，避免登录状态混乱
-        self.cookies.clear()
-        self._login(username, password, *args, **kwargs)
+        with self.login_lock:
+            self.clear_site_state()
+            self._login(username, password, **kwargs)
 
     @abstractmethod
-    def _login(self, username, password, *args, **kwargs):
+    def _login(self, username: str, password: str, **kwargs: object) -> None:
         """
         登录。此方法应当被重载，以便实际实现登录的操作。
         """
 
-    def re_login(self, username, password, *args, **kwargs):
+    def re_login(self, username: str, password: str, **kwargs: object) -> None:
         """
-        重新登录。此方法应当被重载，实现重新登录的操作。
+        重新登录指定的网站。
         """
-        # 必须清除目前已有的 cookies，避免登录状态混乱
-        self.cookies.clear()
-        self._re_login(username, password, *args, **kwargs)
+        with self.login_lock:
+            self.clear_site_state()
+            self._re_login(username, password, **kwargs)
 
     @abstractmethod
-    def _re_login(self, username, password, *args, **kwargs):
+    def _re_login(self, username: str, password: str, **kwargs: object) -> None:
         """
         重新登录。此方法应当被重载，以便实际实现重新登录的操作。
         """
 
-    def request(self, method, url, *args, **kwargs):
+    def request(self, method: str, url: str, **kwargs: object) -> requests.Response:
         """
-        重载 request 方法，记录上次请求时间
+        重载 request 方法，记录上次请求时间，并增加站点特有的 header
         """
         self.reset_timeout()
-        return super().request(method, url, *args, **kwargs)
+        self.backend.reset_timeout()
+
+        request_headers = kwargs.pop("headers", None)
+        headers: dict[str, str] = {}
+        # 使用公用 headers
+        headers.update(self.backend.session.headers)
+        # 增加站点特殊要求的 headers
+        headers.update(self.headers)
+        if request_headers is not None:
+            if not isinstance(request_headers, Mapping):
+                raise TypeError("headers should be a mapping")
+            for key, value in request_headers.items():
+                headers[str(key)] = str(value)
+
+        return self.backend.session.request(method, url, headers=headers, **kwargs)
+
+    def get(self, url: str, **kwargs: object) -> requests.Response:
+        """发起 GET 请求。"""
+        return self.request("GET", url, **kwargs)
+
+    def post(self, url: str, **kwargs: object) -> requests.Response:
+        """发起 POST 请求。"""
+        return self.request("POST", url, **kwargs)
+
+    def set_backend(self, backend: SessionBackend) -> None:
+        """切换当前站点适配器使用的共享后端。"""
+        self.backend = backend
+
+    def clear_site_state(self) -> None:
+        """清理当前站点适配器状态，不清理共享 cookie。"""
+        self._has_login = False
+        self.headers.clear()
+        self.login_method = None
+
+    def clear_backend_cookies(self) -> None:
+        """清理当前访问方式共享后端的全部 cookie。"""
+        self.backend.clear_cookies()
+        self.clear_site_state()
+
+    def close(self) -> None:
+        """关闭当前适配器使用的共享后端。"""
+        self.backend.close()
 
     def has_timeout(self) -> bool:
         """
         检查是否需要重新登录
         """
-        if time.time() - self._last_request_time > self._timeout:
-            return True
-        return False
+        return time.time() - self._last_request_time > self._timeout
 
-    def reset_timeout(self):
+    def reset_timeout(self) -> None:
         """
         重置超时时间为 self._timeout 那么长之后
         """

--- a/app/sessions/gmis_session.py
+++ b/app/sessions/gmis_session.py
@@ -32,3 +32,16 @@ class GMISSession(CommonLoginSession):
         self.has_login = True
 
     _re_login = _login
+
+    def validate_login(self) -> bool:
+        """通过研究生课表页面验证站点登录态。"""
+        response = self.get(
+            "https://gmis.xjtu.edu.cn/pyxx/pygl/xskbcx",
+            timeout=10,
+            _skip_auth_check=True,
+        )
+        if not response.ok or self.is_auth_failure_response(response):
+            return False
+
+        page = response.text
+        return "drpxq" in page or "xskbcx" in page or "课表" in page

--- a/app/sessions/gmis_session.py
+++ b/app/sessions/gmis_session.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from auth import GMIS_LOGIN_URL
 from auth.new_login import NewLogin
+from app.utils.interactive_login import login_with_optional_mfa
 from .common_session import CommonLoginSession
 from ..utils import cfg
 
@@ -11,10 +12,21 @@ class GMISSession(CommonLoginSession):
     ehall.xjtu.edu.cn 登录用的 Session
     """
     site_key = "gmis"
+    site_name = "研究生管理信息系统"
 
     def _login(self, username: str, password: str, **kwargs: object) -> None:
         login_util = NewLogin(GMIS_LOGIN_URL, session=self, visitor_id=str(cfg.loginId.value))
-        login_util.login_or_raise(username, password, account_type=NewLogin.POSTGRADUATE)
+        account, mfa_provider = self.get_login_context(kwargs)
+        login_with_optional_mfa(
+            login_util,
+            username,
+            password,
+            account,
+            mfa_provider,
+            account_type=NewLogin.POSTGRADUATE,
+            site_key=self.site_key,
+            site_name=self.site_name,
+        )
 
         self.reset_timeout()
         self.has_login = True

--- a/app/sessions/gmis_session.py
+++ b/app/sessions/gmis_session.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from auth import GMIS_LOGIN_URL
 from auth.new_login import NewLogin
 from .common_session import CommonLoginSession
@@ -8,7 +10,9 @@ class GMISSession(CommonLoginSession):
     """
     ehall.xjtu.edu.cn 登录用的 Session
     """
-    def _login(self, username, password, *args, **kwargs):
+    site_key = "gmis"
+
+    def _login(self, username: str, password: str, **kwargs: object) -> None:
         login_util = NewLogin(GMIS_LOGIN_URL, session=self, visitor_id=str(cfg.loginId.value))
         login_util.login_or_raise(username, password, account_type=NewLogin.POSTGRADUATE)
 

--- a/app/sessions/gste_session.py
+++ b/app/sessions/gste_session.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import enum
 
 from app.sessions.common_session import CommonLoginSession
+from app.sessions.session_backend import AccessMode, SessionBackend
 from app.utils import cfg
-from attendance.attendance import AttendanceNewLogin, AttendanceNewWebVPNLogin
 from auth import WEBVPN_LOGIN_URL, GSTE_LOGIN_URL
 from auth.new_login import NewLogin, NewWebVPNLogin
 
@@ -12,15 +14,21 @@ class GSTESession(CommonLoginSession):
     gste.xjtu.edu.cn 登录用的 Session
     此网站要求校园网内访问，因此校外必须采用 WebVPN 访问
     """
+    site_key = "gste"
+    supports_webvpn = True
+
     class LoginMethod(enum.Enum):
         NORMAL = 0
         WEBVPN = 1
 
-    def __init__(self, time=15*60):
-        super().__init__(time)
-        self.login_method = None
+    def __init__(self, backend: SessionBackend | None = None, webvpn_backend: SessionBackend | None = None,
+                 timeout: int = 15 * 60) -> None:
+        super().__init__(backend=backend, timeout=timeout)
+        self.normal_backend = self.backend
+        self.webvpn_backend = webvpn_backend or SessionBackend(AccessMode.WEBVPN, timeout=timeout)
 
-    def _login(self, username, password, *args, **kwargs):
+    def _login(self, username: str, password: str, **kwargs: object) -> None:
+        self.set_backend(self.normal_backend)
         login_util = NewLogin(GSTE_LOGIN_URL, session=self, visitor_id=str(cfg.loginId.value))
         login_util.login_or_raise(username, password)
 
@@ -29,20 +37,27 @@ class GSTESession(CommonLoginSession):
         self.reset_timeout()
         self.has_login = True
 
-    def webvpn_login(self, username, password):
+    def webvpn_login(self, username: str, password: str) -> None:
+        """通过 WebVPN 登录研究生评教系统。"""
         # 目前 WebVPN 访问分为两个步骤
         # 1. 登录 WebVPN 自身，此时采用不经过 WebVPN 中介的接口
         # 2. 登录 WebVPN 之后，再登录一次目标网站。此时采用经过 WebVPN 中介的接口
-        self.cookies.clear()
-        login_util = NewLogin(WEBVPN_LOGIN_URL, self, visitor_id=str(cfg.loginId.value))
-        login_util.login_or_raise(username, password)
+        with self.login_lock:
+            self.clear_site_state()
+            self.set_backend(self.webvpn_backend)
 
-        gste_login_util = NewWebVPNLogin(GSTE_LOGIN_URL, self, visitor_id=str(cfg.loginId.value))
-        gste_login_util.login_or_raise(username, password)
+            with self.webvpn_backend.login_lock:
+                if not self.webvpn_backend.has_login:
+                    login_util = NewLogin(WEBVPN_LOGIN_URL, self, visitor_id=str(cfg.loginId.value))
+                    login_util.login_or_raise(username, password)
+                    self.webvpn_backend.has_login = True
 
-        self.login_method = self.LoginMethod.WEBVPN
+            gste_login_util = NewWebVPNLogin(GSTE_LOGIN_URL, self, visitor_id=str(cfg.loginId.value))
+            gste_login_util.login_or_raise(username, password)
 
-        self.reset_timeout()
-        self.has_login = True
+            self.login_method = self.LoginMethod.WEBVPN
+
+            self.reset_timeout()
+            self.has_login = True
 
     _re_login = _login

--- a/app/sessions/gste_session.py
+++ b/app/sessions/gste_session.py
@@ -5,6 +5,7 @@ import enum
 from app.sessions.common_session import CommonLoginSession
 from app.sessions.session_backend import AccessMode, SessionBackend
 from app.utils import cfg
+from app.utils.interactive_login import login_with_optional_mfa
 from auth import WEBVPN_LOGIN_URL, GSTE_LOGIN_URL
 from auth.new_login import NewLogin, NewWebVPNLogin
 
@@ -15,6 +16,7 @@ class GSTESession(CommonLoginSession):
     此网站要求校园网内访问，因此校外必须采用 WebVPN 访问
     """
     site_key = "gste"
+    site_name = "研究生评教系统"
     supports_webvpn = True
 
     class LoginMethod(enum.Enum):
@@ -30,14 +32,24 @@ class GSTESession(CommonLoginSession):
     def _login(self, username: str, password: str, **kwargs: object) -> None:
         self.set_backend(self.normal_backend)
         login_util = NewLogin(GSTE_LOGIN_URL, session=self, visitor_id=str(cfg.loginId.value))
-        login_util.login_or_raise(username, password)
+        account, mfa_provider = self.get_login_context(kwargs)
+        login_with_optional_mfa(
+            login_util,
+            username,
+            password,
+            account,
+            mfa_provider,
+            account_type=NewLogin.POSTGRADUATE,
+            site_key=self.site_key,
+            site_name=self.site_name,
+        )
 
         self.login_method = self.LoginMethod.NORMAL
 
         self.reset_timeout()
         self.has_login = True
 
-    def webvpn_login(self, username: str, password: str) -> None:
+    def webvpn_login(self, username: str, password: str, **kwargs: object) -> None:
         """通过 WebVPN 登录研究生评教系统。"""
         # 目前 WebVPN 访问分为两个步骤
         # 1. 登录 WebVPN 自身，此时采用不经过 WebVPN 中介的接口
@@ -45,15 +57,34 @@ class GSTESession(CommonLoginSession):
         with self.login_lock:
             self.clear_site_state()
             self.set_backend(self.webvpn_backend)
+            account, mfa_provider = self.get_login_context(kwargs)
 
             with self.webvpn_backend.login_lock:
                 if not self.webvpn_backend.has_login:
                     login_util = NewLogin(WEBVPN_LOGIN_URL, self, visitor_id=str(cfg.loginId.value))
-                    login_util.login_or_raise(username, password)
+                    login_with_optional_mfa(
+                        login_util,
+                        username,
+                        password,
+                        account,
+                        mfa_provider,
+                        account_type=NewLogin.POSTGRADUATE,
+                        site_key="webvpn",
+                        site_name="WebVPN",
+                    )
                     self.webvpn_backend.has_login = True
 
             gste_login_util = NewWebVPNLogin(GSTE_LOGIN_URL, self, visitor_id=str(cfg.loginId.value))
-            gste_login_util.login_or_raise(username, password)
+            login_with_optional_mfa(
+                gste_login_util,
+                username,
+                password,
+                account,
+                mfa_provider,
+                account_type=NewLogin.POSTGRADUATE,
+                site_key=self.site_key,
+                site_name=self.site_name,
+            )
 
             self.login_method = self.LoginMethod.WEBVPN
 

--- a/app/sessions/gste_session.py
+++ b/app/sessions/gste_session.py
@@ -6,7 +6,7 @@ from app.sessions.common_session import CommonLoginSession
 from app.sessions.session_backend import AccessMode, SessionBackend
 from app.utils import cfg
 from app.utils.interactive_login import login_with_optional_mfa
-from auth import WEBVPN_LOGIN_URL, GSTE_LOGIN_URL
+from auth import WEBVPN_LOGIN_URL, GSTE_LOGIN_URL, getVPNUrl
 from auth.new_login import NewLogin, NewWebVPNLogin
 
 
@@ -60,6 +60,8 @@ class GSTESession(CommonLoginSession):
             account, mfa_provider = self.get_login_context(kwargs)
 
             with self.webvpn_backend.login_lock:
+                if self.webvpn_backend.has_timeout():
+                    self.webvpn_backend.has_login = False
                 if not self.webvpn_backend.has_login:
                     login_util = NewLogin(WEBVPN_LOGIN_URL, self, visitor_id=str(cfg.loginId.value))
                     login_with_optional_mfa(
@@ -92,3 +94,16 @@ class GSTESession(CommonLoginSession):
             self.has_login = True
 
     _re_login = _login
+
+    def validate_login(self) -> bool:
+        """通过研究生评教问卷列表页验证站点登录态。"""
+        url = "http://gste.xjtu.edu.cn/app/sshd4Stu/list.do"
+        if self.login_method == self.LoginMethod.WEBVPN:
+            url = getVPNUrl(url)
+
+        response = self.get(url, timeout=10, _skip_auth_check=True)
+        if not response.ok or self.is_auth_failure_response(response):
+            return False
+
+        page = response.text
+        return "sshd4Stu" in page or "questionnaire" in page or "评教" in page or response.url.startswith(url)

--- a/app/sessions/jwapp_session.py
+++ b/app/sessions/jwapp_session.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from app.sessions.common_session import CommonLoginSession
 from app.utils import cfg
+from app.utils.interactive_login import login_with_optional_mfa
+from auth.new_login import NewLogin
 from jwapp.util import JwappNewLogin
 
 
@@ -10,10 +12,21 @@ class JwappSession(CommonLoginSession):
     jwapp.xjtu.edu.cn 登录用的 Session
     """
     site_key = "jwapp"
+    site_name = "移动教务系统"
 
     def _login(self, username: str, password: str, **kwargs: object) -> None:
         login_util = JwappNewLogin(session=self, visitor_id=str(cfg.loginId.value))
-        login_util.login_or_raise(username, password)
+        account, mfa_provider = self.get_login_context(kwargs)
+        login_with_optional_mfa(
+            login_util,
+            username,
+            password,
+            account,
+            mfa_provider,
+            account_type=NewLogin.UNDERGRADUATE,
+            site_key=self.site_key,
+            site_name=self.site_name,
+        )
 
         self.reset_timeout()
         self.has_login = True

--- a/app/sessions/jwapp_session.py
+++ b/app/sessions/jwapp_session.py
@@ -32,3 +32,23 @@ class JwappSession(CommonLoginSession):
         self.has_login = True
 
     _re_login = _login
+
+    def validate_login(self) -> bool:
+        """通过移动教务的通用接口验证站点登录态。"""
+        if "Authorization" not in self.headers:
+            return False
+
+        response = self.get(
+            "https://jwapp.xjtu.edu.cn/api/biz/v410/common/school/time",
+            timeout=10,
+            _skip_auth_check=True,
+        )
+        if not response.ok or self.is_auth_failure_response(response):
+            return False
+
+        try:
+            result = response.json()
+        except ValueError:
+            return False
+
+        return result.get("code") == 200

--- a/app/sessions/jwapp_session.py
+++ b/app/sessions/jwapp_session.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from app.sessions.common_session import CommonLoginSession
 from app.utils import cfg
 from jwapp.util import JwappNewLogin
@@ -7,7 +9,9 @@ class JwappSession(CommonLoginSession):
     """
     jwapp.xjtu.edu.cn 登录用的 Session
     """
-    def _login(self, username, password, *args, **kwargs):
+    site_key = "jwapp"
+
+    def _login(self, username: str, password: str, **kwargs: object) -> None:
         login_util = JwappNewLogin(session=self, visitor_id=str(cfg.loginId.value))
         login_util.login_or_raise(username, password)
 

--- a/app/sessions/jwxt_session.py
+++ b/app/sessions/jwxt_session.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from auth.constant import JWXT_LOGIN_URL
 from auth.new_login import NewLogin
 from .common_session import CommonLoginSession
@@ -8,7 +10,9 @@ class JWXTSession(CommonLoginSession):
     """
     ehall.xjtu.edu.cn 登录用的 Session
     """
-    def _login(self, username, password, *args, **kwargs):
+    site_key = "jwxt"
+
+    def _login(self, username: str, password: str, **kwargs: object) -> None:
         login_util = NewLogin(JWXT_LOGIN_URL, session=self, visitor_id=str(cfg.loginId.value))
         login_util.login_or_raise(username, password)
 

--- a/app/sessions/jwxt_session.py
+++ b/app/sessions/jwxt_session.py
@@ -31,3 +31,23 @@ class JWXTSession(CommonLoginSession):
         self.has_login = True
 
     _re_login = _login
+
+    def validate_login(self) -> bool:
+        """通过教务系统当前用户接口验证站点登录态。"""
+        response = self.get(
+            "https://jwxt.xjtu.edu.cn/jwapp/sys/homeapp/api/home/currentUser.do",
+            headers={
+                "Referer": "https://jwxt.xjtu.edu.cn/jwapp/sys/homeapp/home/index.html?av=&contextPath=/jwapp"
+            },
+            timeout=10,
+            _skip_auth_check=True,
+        )
+        if not response.ok or self.is_auth_failure_response(response):
+            return False
+
+        try:
+            result = response.json()
+        except ValueError:
+            return False
+
+        return result.get("code") == "0" and isinstance(result.get("datas"), dict)

--- a/app/sessions/jwxt_session.py
+++ b/app/sessions/jwxt_session.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from auth.constant import JWXT_LOGIN_URL
 from auth.new_login import NewLogin
+from app.utils.interactive_login import login_with_optional_mfa
 from .common_session import CommonLoginSession
 from ..utils import cfg
 
@@ -11,10 +12,20 @@ class JWXTSession(CommonLoginSession):
     ehall.xjtu.edu.cn 登录用的 Session
     """
     site_key = "jwxt"
+    site_name = "本科教务系统"
 
     def _login(self, username: str, password: str, **kwargs: object) -> None:
         login_util = NewLogin(JWXT_LOGIN_URL, session=self, visitor_id=str(cfg.loginId.value))
-        login_util.login_or_raise(username, password)
+        account, mfa_provider = self.get_login_context(kwargs)
+        login_with_optional_mfa(
+            login_util,
+            username,
+            password,
+            account,
+            mfa_provider,
+            site_key=self.site_key,
+            site_name=self.site_name,
+        )
 
         self.reset_timeout()
         self.has_login = True

--- a/app/sessions/lms_session.py
+++ b/app/sessions/lms_session.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from auth.constant import LMS_LOGIN_URL
 from auth.new_login import NewLogin
 from .common_session import CommonLoginSession
@@ -8,7 +10,9 @@ class LMSSession(CommonLoginSession):
     """
     lms.xjtu.edu.cn 登录用的 Session
     """
-    def _login(self, username, password, *args, **kwargs):
+    site_key = "lms"
+
+    def _login(self, username: str, password: str, **kwargs: object) -> None:
         login_url = LMS_LOGIN_URL
         if not login_url.startswith(("http://", "https://")):
             login_url = f"https://{login_url}"

--- a/app/sessions/lms_session.py
+++ b/app/sessions/lms_session.py
@@ -36,6 +36,19 @@ class LMSSession(CommonLoginSession):
 
     _re_login = _login
 
+    def validate_login(self) -> bool:
+        """通过思源学堂用户主页验证站点登录态。"""
+        response = self.get(
+            "https://lms.xjtu.edu.cn/user/index",
+            timeout=10,
+            _skip_auth_check=True,
+        )
+        if not response.ok or self.is_auth_failure_response(response):
+            return False
+
+        page = response.text
+        return "globalData" in page and "user" in page
+
 
 # Backward compatibility for previous class name.
 LMSLoginSession = LMSSession

--- a/app/sessions/lms_session.py
+++ b/app/sessions/lms_session.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from auth.constant import LMS_LOGIN_URL
 from auth.new_login import NewLogin
+from app.utils.interactive_login import login_with_optional_mfa
 from .common_session import CommonLoginSession
 from ..utils import cfg
 
@@ -11,6 +12,7 @@ class LMSSession(CommonLoginSession):
     lms.xjtu.edu.cn 登录用的 Session
     """
     site_key = "lms"
+    site_name = "思源学堂"
 
     def _login(self, username: str, password: str, **kwargs: object) -> None:
         login_url = LMS_LOGIN_URL
@@ -18,7 +20,16 @@ class LMSSession(CommonLoginSession):
             login_url = f"https://{login_url}"
 
         login_util = NewLogin(login_url, session=self, visitor_id=str(cfg.loginId.value))
-        login_util.login_or_raise(username, password)
+        account, mfa_provider = self.get_login_context(kwargs)
+        login_with_optional_mfa(
+            login_util,
+            username,
+            password,
+            account,
+            mfa_provider,
+            site_key=self.site_key,
+            site_name=self.site_name,
+        )
 
         self.reset_timeout()
         self.has_login = True

--- a/app/sessions/session_backend.py
+++ b/app/sessions/session_backend.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import enum
+import threading
+import time
+
+import requests
+
+
+class AccessMode(enum.Enum):
+    """表示底层会话的访问方式。"""
+
+    NORMAL = "normal"
+    WEBVPN = "webvpn"
+
+
+class SessionBackend:
+    """同一账号、同一访问方式下共享的底层请求后端。"""
+
+    def __init__(self, access_mode: AccessMode, timeout: int = 15 * 60) -> None:
+        """创建一个共享请求后端。"""
+        from app.utils.config import cfg
+
+        self.access_mode = access_mode
+        self.session = requests.Session()
+        self.session.headers.update({"User-Agent": cfg.userAgent.value})
+        self.timeout = timeout
+        self.last_request_time = 0.0
+        self.has_login = False
+        self.login_lock = threading.RLock()
+
+    def reset_timeout(self) -> None:
+        """刷新后端最近请求时间。"""
+        self.last_request_time = time.time()
+
+    def has_timeout(self) -> bool:
+        """判断后端登录态是否已经超过本地超时时间。"""
+        return time.time() - self.last_request_time > self.timeout
+
+    def clear_cookies(self) -> None:
+        """清理当前后端的全部 cookie。"""
+        self.session.cookies.clear()
+        self.has_login = False
+
+    def close(self) -> None:
+        """关闭底层 requests session。"""
+        self.session.close()

--- a/app/sub_interfaces/LoginInterface.py
+++ b/app/sub_interfaces/LoginInterface.py
@@ -5,9 +5,9 @@ from qfluentwidgets import TitleLabel, ScrollArea, LineEdit, PasswordLineEdit, P
     ImageLabel, InfoBar, InfoBarPosition, StateToolTip, isDarkTheme, Theme, MessageBox
 
 from auth.new_login import NewLogin
-from .VerifyCodeDialog import VerifyCodeDialog
 from ..threads.LoginThreads import LoginThread
 from ..utils import StyleSheet, cfg, accounts
+from ..utils.mfa import MFAProvider
 
 
 class LoginInterface(ScrollArea):
@@ -18,7 +18,7 @@ class LoginInterface(ScrollArea):
     loginFail = pyqtSignal()
     cancel = pyqtSignal()
 
-    def __init__(self, parent=None):
+    def __init__(self, parent=None, mfa_provider: MFAProvider | None = None):
         super().__init__(parent)
 
         self.setObjectName("LoginInterface")
@@ -84,7 +84,9 @@ class LoginInterface(ScrollArea):
 
         # 控制逻辑用的变量
         self._captcha_required = False
-        self.__thread = LoginThread(LoginThread.LoginChoice.GET_SHOW_CAPTCHA, "", "", parent=self)
+        self.mfa_provider = mfa_provider
+        self.__thread = LoginThread(LoginThread.LoginChoice.GET_SHOW_CAPTCHA, "", "", mfa_provider=self.mfa_provider,
+                                    parent=self)
         # 在用户点击登录按钮时立刻保存变量，防止登录到一半结果输入框里东西被用户改了（
         self.__username = ""
         self.__password = ""
@@ -97,7 +99,6 @@ class LoginInterface(ScrollArea):
         self.loginSuccess.connect(self.on_login_success)
 
         self.__thread.needChooseAccount.connect(self.__on_choose_account)
-        self.__thread.needMFA.connect(self.__on_need_mfa)
         self.__thread.loginSuccess.connect(self.__on_login_success)
         self.__thread.loginFailed.connect(self.__on_login_fail)
         self.__thread.captchaCode.connect(self.__on_receive_captcha_code)
@@ -222,37 +223,6 @@ class LoginInterface(ScrollArea):
 
         self.__thread.choice = LoginThread.LoginChoice.FINISH_LOGIN
         self.__thread.start()
-
-    @pyqtSlot(str)
-    def __on_need_mfa(self, phone_number: str):
-        @pyqtSlot()
-        def __on_click_send_mfa():
-            self.__thread.choice = LoginThread.LoginChoice.MFA_SEND
-            self.__thread.start()
-
-        @pyqtSlot(bool, str)
-        def __on_report_send_mfa_result(success: bool, msg: str):
-            w.reportSendResult(success, msg)
-
-        w = VerifyCodeDialog(phone_number, self)
-        w.sendSignal.connect(__on_click_send_mfa)
-
-        try:
-            self.__thread.sendMFAResult.disconnect()
-        except TypeError:
-            pass
-        self.__thread.sendMFAResult.connect(__on_report_send_mfa_result)
-
-        if w.exec():
-            code = w.code
-            self.__thread.choice = LoginThread.LoginChoice.MFA_VERIFY
-            self.__thread._mfaCode = code
-            self.__thread.trustAgent = w.trust
-            self.__thread.start()
-        else:
-            # 需要重置一下 login 对象
-            self.resetLogin()
-            self._unlock(False)
 
     @pyqtSlot()
     def __on_login_success(self):

--- a/app/sub_interfaces/VerifyCodeDialog.py
+++ b/app/sub_interfaces/VerifyCodeDialog.py
@@ -6,6 +6,8 @@ from PyQt5.QtWidgets import QHBoxLayout
 from qfluentwidgets import MessageBoxBase, TitleLabel, CaptionLabel, LineEdit, PrimaryPushButton, \
     BodyLabel, InfoBar, CheckBox
 
+from app.utils.mfa import MFARequest
+
 
 class VerifyCodeDialog(MessageBoxBase):
     """用户选择发送手机验证码的对话框"""
@@ -13,15 +15,20 @@ class VerifyCodeDialog(MessageBoxBase):
     codeSignal = pyqtSignal(str, bool)
     # 点击发送按键的信号
     sendSignal = pyqtSignal()
+    # 用户取消验证的信号
+    cancelSignal = pyqtSignal()
 
-    def __init__(self, phone_number: str, parent=None):
+    def __init__(self, request: MFARequest, parent=None):
         super().__init__(parent)
 
-        self.title = TitleLabel(self.tr("两步验证"), self)
-        self.hint = CaptionLabel(self.tr("登录系统认为当前登录环境异常，需通过安全验证确定是本人操作后才可继续登录"), self)
+        self.title = TitleLabel(self.tr("需要安全验证"), self)
+        self.hint = CaptionLabel(
+            self.tr("学校统一认证要求完成两步验证后继续访问「{0}」。").format(request.site_name),
+            self,
+        )
 
         self.sendLayout = QHBoxLayout()
-        self.phoneNumberDisplay = BodyLabel(phone_number, self)
+        self.phoneNumberDisplay = BodyLabel(request.phone_number, self)
 
         self.sendButton = PrimaryPushButton(self.tr("发送验证码"), self)
         self.sendLayout.addWidget(self.phoneNumberDisplay, stretch=1)
@@ -118,3 +125,10 @@ class VerifyCodeDialog(MessageBoxBase):
             self.resendTimer.stop()
             self.sendButton.setText(self.tr("发送验证码"))
             self.sendButton.setEnabled(True)
+
+    def reject(self) -> None:
+        """
+        处理用户取消 MFA 验证。
+        """
+        self.cancelSignal.emit()
+        super().reject()

--- a/app/threads/AttendanceFlowThread.py
+++ b/app/threads/AttendanceFlowThread.py
@@ -54,7 +54,7 @@ class AttendanceFlowThread(ProcessThread):
     def normal_login(self):
         self.setIndeterminate.emit(True)
         self.messageChanged.emit(self.tr("正在直接登录考勤系统..."))
-        self.session.login(
+        self.session.ensure_login(
             self.account.username,
             self.account.password,
             is_postgraduate=accounts.current.type == accounts.current.POSTGRADUATE,
@@ -117,7 +117,7 @@ class AttendanceFlowThread(ProcessThread):
                 self.successMessage.emit(self.tr("直接登录考勤系统成功。"))
                 self.hasFinished.emit()
             elif self.choice == AttendanceFlowChoice.SEARCH:
-                if not self.session.has_login:
+                if not self.session.has_login or not self.session.validate_login():
                     if self.last_login_choice is not None:
                         self.login_again()
                         result = self.search(self.session)

--- a/app/threads/AttendanceFlowThread.py
+++ b/app/threads/AttendanceFlowThread.py
@@ -7,6 +7,7 @@ import requests
 from auth import ServerError
 from ..sessions.attendance_session import AttendanceSession
 from ..utils import Account, cfg, logger, accounts
+from ..utils.mfa import MFACancelledError, MFAUnavailableError
 from attendance.attendance import Attendance
 from .ProcessWidget import ProcessThread
 from PyQt5.QtCore import pyqtSignal
@@ -41,13 +42,25 @@ class AttendanceFlowThread(ProcessThread):
     def webvpn_login(self):
         self.setIndeterminate.emit(True)
         self.messageChanged.emit(self.tr("正在通过 WebVPN 登录考勤系统..."))
-        self.session.webvpn_login(self.account.username, self.account.password, is_postgraduate=accounts.current.type == accounts.current.POSTGRADUATE)
+        self.session.webvpn_login(
+            self.account.username,
+            self.account.password,
+            is_postgraduate=accounts.current.type == accounts.current.POSTGRADUATE,
+            account=self.account,
+            mfa_provider=self.account.session_manager.mfa_provider,
+        )
         self.messageChanged.emit(self.tr("登录 WebVPN 成功。"))
 
     def normal_login(self):
         self.setIndeterminate.emit(True)
         self.messageChanged.emit(self.tr("正在直接登录考勤系统..."))
-        self.session.login(self.account.username, self.account.password, is_postgraduate=accounts.current.type == accounts.current.POSTGRADUATE)
+        self.session.login(
+            self.account.username,
+            self.account.password,
+            is_postgraduate=accounts.current.type == accounts.current.POSTGRADUATE,
+            account=self.account,
+            mfa_provider=self.account.session_manager.mfa_provider,
+        )
         self.messageChanged.emit(self.tr("直接登录考勤系统成功。"))
 
     def search(self, session):
@@ -121,6 +134,14 @@ class AttendanceFlowThread(ProcessThread):
                     self.hasFinished.emit()
             else:
                 raise ValueError(f"{self.choice} is not a valid choice. ")
+        except MFACancelledError as e:
+            logger.info("MFA 验证已取消：%s", e)
+            self.error.emit(self.tr("安全验证已取消"), self.tr("已取消安全验证，本次操作未完成。"))
+            self.canceled.emit()
+        except MFAUnavailableError as e:
+            logger.error("MFA 交互不可用", exc_info=True)
+            self.error.emit(self.tr("登录问题"), str(e))
+            self.canceled.emit()
         except ServerError as e:
             logger.error("服务器错误", exc_info=True)
             if e.code == 102:

--- a/app/threads/EmptyRoomThread.py
+++ b/app/threads/EmptyRoomThread.py
@@ -9,6 +9,7 @@ from ..sessions.jwxt_session import JWXTSession
 from ..threads.ProcessWidget import ProcessThread
 from ..utils import accounts, logger, cfg
 from ..utils.cache import CacheManager
+from ..utils.mfa import MFACancelledError, MFAUnavailableError
 
 
 class EmptyRoomThread(ProcessThread):
@@ -39,7 +40,12 @@ class EmptyRoomThread(ProcessThread):
         """
         self.setIndeterminate.emit(True)
         self.messageChanged.emit(self.tr("正在登录教务系统..."))
-        self.session.login(accounts.current.username, accounts.current.password)
+        self.session.login(
+            accounts.current.username,
+            accounts.current.password,
+            account=accounts.current,
+            mfa_provider=accounts.current.session_manager.mfa_provider,
+        )
         if not self.can_run:
             return False
         # 进入课表页面
@@ -156,6 +162,14 @@ class EmptyRoomThread(ProcessThread):
                         if single["name"] in result_diction:
                             result_diction[single["name"]]["status"][period - 1] = 0
 
+        except MFACancelledError as e:
+            logger.info("MFA 验证已取消：%s", e)
+            self.error.emit(self.tr("安全验证已取消"), self.tr("已取消安全验证，本次操作未完成。"))
+            self.canceled.emit()
+        except MFAUnavailableError as e:
+            logger.error("MFA 交互不可用", exc_info=True)
+            self.error.emit(self.tr("登录问题"), str(e))
+            self.canceled.emit()
         except ServerError as e:
             logger.error("服务器错误", exc_info=True)
             if e.code == 102:

--- a/app/threads/EmptyRoomThread.py
+++ b/app/threads/EmptyRoomThread.py
@@ -40,7 +40,7 @@ class EmptyRoomThread(ProcessThread):
         """
         self.setIndeterminate.emit(True)
         self.messageChanged.emit(self.tr("正在登录教务系统..."))
-        self.session.login(
+        self.session.ensure_login(
             accounts.current.username,
             accounts.current.password,
             account=accounts.current,
@@ -65,14 +65,10 @@ class EmptyRoomThread(ProcessThread):
             return
 
         try:
-            # 如果当前账户已经登录，重建代理对象，防止出现 util 和 session 不对应的情况。
-            if self.session.has_login:
-                self.util = EmptyRoom(self.session)
-            else:
-                result = self.login()
-                if not result:
-                    self.canceled.emit()
-                    return
+            result = self.login()
+            if not result:
+                self.canceled.emit()
+                return
 
             cache_manager = CacheManager()
 

--- a/app/threads/ExamScheduleThread.py
+++ b/app/threads/ExamScheduleThread.py
@@ -7,6 +7,7 @@ from .ProcessWidget import ProcessThread
 from ..sessions.jwxt_session import JWXTSession
 from ..utils import logger
 from ..utils.account import accounts
+from ..utils.mfa import MFACancelledError, MFAUnavailableError
 
 
 class ExamScheduleThread(ProcessThread):
@@ -40,7 +41,12 @@ class ExamScheduleThread(ProcessThread):
         """
         self.setIndeterminate.emit(True)
         self.messageChanged.emit(self.tr("正在登录教务系统..."))
-        self.session.login(accounts.current.username, accounts.current.password)
+        self.session.login(
+            accounts.current.username,
+            accounts.current.password,
+            account=accounts.current,
+            mfa_provider=accounts.current.session_manager.mfa_provider,
+        )
         self.session.has_login = True
 
         if not self.can_run:
@@ -77,6 +83,14 @@ class ExamScheduleThread(ProcessThread):
 
             self.progressChanged.emit(100)
 
+        except MFACancelledError as e:
+            logger.info("MFA 验证已取消：%s", e)
+            self.error.emit(self.tr("安全验证已取消"), self.tr("已取消安全验证，本次操作未完成。"))
+            self.canceled.emit()
+        except MFAUnavailableError as e:
+            logger.error("MFA 交互不可用", exc_info=True)
+            self.error.emit(self.tr("登录问题"), str(e))
+            self.canceled.emit()
         except ServerError as e:
             logger.error("服务器错误", exc_info=True)
             if e.code == 102:

--- a/app/threads/ExamScheduleThread.py
+++ b/app/threads/ExamScheduleThread.py
@@ -41,13 +41,12 @@ class ExamScheduleThread(ProcessThread):
         """
         self.setIndeterminate.emit(True)
         self.messageChanged.emit(self.tr("正在登录教务系统..."))
-        self.session.login(
+        self.session.ensure_login(
             accounts.current.username,
             accounts.current.password,
             account=accounts.current,
             mfa_provider=accounts.current.session_manager.mfa_provider,
         )
-        self.session.has_login = True
 
         if not self.can_run:
             return False
@@ -68,14 +67,10 @@ class ExamScheduleThread(ProcessThread):
             return
 
         try:
-            # 如果当前账户已经登录，重建代理对象，防止出现 util 和 session 不对应的情况。
-            if self.session.has_login:
-                self.util = Schedule(self.session)
-            else:
-                result = self.login()
-                if not result:
-                    self.canceled.emit()
-                    return
+            result = self.login()
+            if not result:
+                self.canceled.emit()
+                return
 
             self.progressChanged.emit(66)
             self.messageChanged.emit("正在获取考试时间...")

--- a/app/threads/GraduateJudgeThread.py
+++ b/app/threads/GraduateJudgeThread.py
@@ -10,6 +10,7 @@ from .ProcessWidget import ProcessThread
 from ..sessions.gmis_session import GMISSession
 from ..sessions.gste_session import GSTESession
 from ..utils import Account, logger, accounts
+from ..utils.mfa import MFACancelledError, MFAUnavailableError
 
 from auth import ServerError
 from enum import Enum
@@ -74,13 +75,23 @@ class GraduateJudgeThread(ProcessThread):
     def webvpn_login(self):
         self.setIndeterminate.emit(True)
         self.messageChanged.emit(self.tr("正在通过 WebVPN 登录评教系统..."))
-        self.session.webvpn_login(self.account.username, self.account.password)
+        self.session.webvpn_login(
+            self.account.username,
+            self.account.password,
+            account=self.account,
+            mfa_provider=self.account.session_manager.mfa_provider,
+        )
         self.messageChanged.emit(self.tr("登录 WebVPN 成功。"))
 
     def normal_login(self):
         self.setIndeterminate.emit(True)
         self.messageChanged.emit(self.tr("正在直接登录评教系统..."))
-        self.session.login(self.account.username, self.account.password)
+        self.session.login(
+            self.account.username,
+            self.account.password,
+            account=self.account,
+            mfa_provider=self.account.session_manager.mfa_provider,
+        )
         self.messageChanged.emit(self.tr("直接登录评教系统成功。"))
 
     def run(self):
@@ -151,7 +162,12 @@ class GraduateJudgeThread(ProcessThread):
                 self.progressChanged.emit(30)
                 if not self.gmis_session.has_login:
                     self.messageChanged.emit(self.tr("正在登录研究生管理信息系统..."))
-                    self.gmis_session.login(self.account.username, self.account.password)
+                    self.gmis_session.login(
+                        self.account.username,
+                        self.account.password,
+                        account=self.account,
+                        mfa_provider=self.account.session_manager.mfa_provider,
+                    )
 
                 if not self.can_run:
                     self.canceled.emit()
@@ -194,7 +210,12 @@ class GraduateJudgeThread(ProcessThread):
                 self.progressChanged.emit(5)
                 if not self.gmis_session.has_login:
                     self.messageChanged.emit(self.tr("正在登录研究生管理信息系统..."))
-                    self.gmis_session.login(self.account.username, self.account.password)
+                    self.gmis_session.login(
+                        self.account.username,
+                        self.account.password,
+                        account=self.account,
+                        mfa_provider=self.account.session_manager.mfa_provider,
+                    )
                 gmis_util = GraduateLessonDetail(self.gmis_session)
 
                 if not self.can_run:
@@ -268,6 +289,14 @@ class GraduateJudgeThread(ProcessThread):
 
             else:
                 raise ValueError(self.tr("未知选项"))
+        except MFACancelledError as e:
+            logger.info("MFA 验证已取消：%s", e)
+            self.error.emit(self.tr("安全验证已取消"), self.tr("已取消安全验证，本次操作未完成。"))
+            self.canceled.emit()
+        except MFAUnavailableError as e:
+            logger.error("MFA 交互不可用", exc_info=True)
+            self.error.emit(self.tr("登录问题"), str(e))
+            self.canceled.emit()
         except ServerError as e:
             logger.error("服务器错误", exc_info=True)
             if e.code == 102:

--- a/app/threads/GraduateJudgeThread.py
+++ b/app/threads/GraduateJudgeThread.py
@@ -86,7 +86,7 @@ class GraduateJudgeThread(ProcessThread):
     def normal_login(self):
         self.setIndeterminate.emit(True)
         self.messageChanged.emit(self.tr("正在直接登录评教系统..."))
-        self.session.login(
+        self.session.ensure_login(
             self.account.username,
             self.account.password,
             account=self.account,
@@ -104,8 +104,8 @@ class GraduateJudgeThread(ProcessThread):
 
         self.progressChanged.emit(0)
         try:
-            # 如果当前账户已经登录，重建代理对象，防止出现 util 和 session 不对应的情况。
-            if self.session.has_login:
+            # 如果当前账户已经登录并且登录态仍有效，重建代理对象，防止 util 和 session 不对应。
+            if self.session.has_login and self.session.validate_login():
                 # 如果当前 session 已经登录，必须沿用当前登录方式。
                 util = GraduateAutoJudge(self.session, use_webvpn=self.session.login_method == self.session.LoginMethod.WEBVPN)
             else:
@@ -160,14 +160,13 @@ class GraduateJudgeThread(ProcessThread):
                 # 开填！
                 # 首先，填写基本信息
                 self.progressChanged.emit(30)
-                if not self.gmis_session.has_login:
-                    self.messageChanged.emit(self.tr("正在登录研究生管理信息系统..."))
-                    self.gmis_session.login(
-                        self.account.username,
-                        self.account.password,
-                        account=self.account,
-                        mfa_provider=self.account.session_manager.mfa_provider,
-                    )
+                self.messageChanged.emit(self.tr("正在登录研究生管理信息系统..."))
+                self.gmis_session.ensure_login(
+                    self.account.username,
+                    self.account.password,
+                    account=self.account,
+                    mfa_provider=self.account.session_manager.mfa_provider,
+                )
 
                 if not self.can_run:
                     self.canceled.emit()
@@ -208,14 +207,13 @@ class GraduateJudgeThread(ProcessThread):
                 # 评教全部课程
                 # 先获得公用内容：登录 GMIS 和获得课程类型信息
                 self.progressChanged.emit(5)
-                if not self.gmis_session.has_login:
-                    self.messageChanged.emit(self.tr("正在登录研究生管理信息系统..."))
-                    self.gmis_session.login(
-                        self.account.username,
-                        self.account.password,
-                        account=self.account,
-                        mfa_provider=self.account.session_manager.mfa_provider,
-                    )
+                self.messageChanged.emit(self.tr("正在登录研究生管理信息系统..."))
+                self.gmis_session.ensure_login(
+                    self.account.username,
+                    self.account.password,
+                    account=self.account,
+                    mfa_provider=self.account.session_manager.mfa_provider,
+                )
                 gmis_util = GraduateLessonDetail(self.gmis_session)
 
                 if not self.can_run:

--- a/app/threads/GraduateScheduleThread.py
+++ b/app/threads/GraduateScheduleThread.py
@@ -8,6 +8,7 @@ from gmis.schedule import GraduateSchedule
 from ..sessions.gmis_session import GMISSession
 from ..threads.ProcessWidget import ProcessThread
 from ..utils import accounts, logger, cfg
+from ..utils.mfa import MFACancelledError, MFAUnavailableError
 
 
 class GraduateScheduleThread(ProcessThread):
@@ -41,7 +42,12 @@ class GraduateScheduleThread(ProcessThread):
         """
         self.setIndeterminate.emit(True)
         self.messageChanged.emit(self.tr("正在登录研究生管理信息系统..."))
-        self.session.login(accounts.current.username, accounts.current.password)
+        self.session.login(
+            accounts.current.username,
+            accounts.current.password,
+            account=accounts.current,
+            mfa_provider=accounts.current.session_manager.mfa_provider,
+        )
         self.session.has_login = True
         if not self.can_run:
             return False
@@ -89,6 +95,14 @@ class GraduateScheduleThread(ProcessThread):
 
             self.progressChanged.emit(100)
 
+        except MFACancelledError as e:
+            logger.info("MFA 验证已取消：%s", e)
+            self.error.emit(self.tr("安全验证已取消"), self.tr("已取消安全验证，本次操作未完成。"))
+            self.canceled.emit()
+        except MFAUnavailableError as e:
+            logger.error("MFA 交互不可用", exc_info=True)
+            self.error.emit(self.tr("登录问题"), str(e))
+            self.canceled.emit()
         except ServerError as e:
             logger.error("服务器错误", exc_info=True)
             if e.code == 102:

--- a/app/threads/GraduateScheduleThread.py
+++ b/app/threads/GraduateScheduleThread.py
@@ -42,13 +42,12 @@ class GraduateScheduleThread(ProcessThread):
         """
         self.setIndeterminate.emit(True)
         self.messageChanged.emit(self.tr("正在登录研究生管理信息系统..."))
-        self.session.login(
+        self.session.ensure_login(
             accounts.current.username,
             accounts.current.password,
             account=accounts.current,
             mfa_provider=accounts.current.session_manager.mfa_provider,
         )
-        self.session.has_login = True
         if not self.can_run:
             return False
 
@@ -72,15 +71,10 @@ class GraduateScheduleThread(ProcessThread):
             return
 
         try:
-            # 如果当前账户已经登录，重建代理对象，防止出现 util 和 session 不对应的情况。
-            if self.session.has_login:
-                self.util = GraduateSchedule(self.session)
-            else:
-                # 手动登录。虽然 EhallSession 有自动登录功能，但是为了显示进度条，还是一步一步手动登录。
-                result = self.login()
-                if not result:
-                    self.canceled.emit()
-                    return
+            result = self.login()
+            if not result:
+                self.canceled.emit()
+                return
 
             self.progressChanged.emit(66)
             self.messageChanged.emit("正在获取课表信息...")

--- a/app/threads/GraduateScoreThread.py
+++ b/app/threads/GraduateScoreThread.py
@@ -6,6 +6,7 @@ from gmis.score import GraduateScore
 from ..sessions.gmis_session import GMISSession
 from ..threads.ProcessWidget import ProcessThread
 from ..utils import accounts, logger, cfg
+from ..utils.mfa import MFACancelledError, MFAUnavailableError
 from auth import ServerError, GMIS_LOGIN_URL
 
 
@@ -38,7 +39,12 @@ class GraduateScoreThread(ProcessThread):
         """
         self.setIndeterminate.emit(True)
         self.messageChanged.emit(self.tr("正在登录研究生信息管理系统..."))
-        self.session.login(accounts.current.username, accounts.current.password)
+        self.session.login(
+            accounts.current.username,
+            accounts.current.password,
+            account=accounts.current,
+            mfa_provider=accounts.current.session_manager.mfa_provider,
+        )
         self.session.has_login = True
         if not self.can_run:
             return False
@@ -78,6 +84,14 @@ class GraduateScoreThread(ProcessThread):
                 return
             result = self.util.grade()
             self.progressChanged.emit(100)
+        except MFACancelledError as e:
+            logger.info("MFA 验证已取消：%s", e)
+            self.error.emit(self.tr("安全验证已取消"), self.tr("已取消安全验证，本次操作未完成。"))
+            self.canceled.emit()
+        except MFAUnavailableError as e:
+            logger.error("MFA 交互不可用", exc_info=True)
+            self.error.emit(self.tr("登录问题"), str(e))
+            self.canceled.emit()
         except ServerError as e:
             logger.error("服务器错误", exc_info=True)
             if e.code == 102:

--- a/app/threads/GraduateScoreThread.py
+++ b/app/threads/GraduateScoreThread.py
@@ -39,13 +39,12 @@ class GraduateScoreThread(ProcessThread):
         """
         self.setIndeterminate.emit(True)
         self.messageChanged.emit(self.tr("正在登录研究生信息管理系统..."))
-        self.session.login(
+        self.session.ensure_login(
             accounts.current.username,
             accounts.current.password,
             account=accounts.current,
             mfa_provider=accounts.current.session_manager.mfa_provider,
         )
-        self.session.has_login = True
         if not self.can_run:
             return False
 
@@ -69,15 +68,10 @@ class GraduateScoreThread(ProcessThread):
         self.progressChanged.emit(0)
 
         try:
-            # 如果当前账户已经登录，重建代理对象，防止出现 util 和 session 不对应的情况。
-            if self.session.has_login:
-                self.util = GraduateScore(self.session)
-            else:
-                # 手动登录。虽然 GMISSession 有自动登录功能，但是为了显示进度条，还是一步一步手动登录。
-                result = self.login()
-                if not result:
-                    self.canceled.emit()
-                    return
+            result = self.login()
+            if not result:
+                self.canceled.emit()
+                return
             self.progressChanged.emit(66)
             self.messageChanged.emit("正在获取成绩...")
             if not self.can_run:

--- a/app/threads/JudgeThread.py
+++ b/app/threads/JudgeThread.py
@@ -51,13 +51,12 @@ class JudgeThread(ProcessThread):
     def login(self) -> bool:
         self.setIndeterminate.emit(True)
         self.messageChanged.emit(self.tr("正在登录教务系统..."))
-        self.session.login(
+        self.session.ensure_login(
             self.account.username,
             self.account.password,
             account=self.account,
             mfa_provider=self.account.session_manager.mfa_provider,
         )
-        self.session.has_login = True
 
         # 进入评教区域
         self.messageChanged.emit(self.tr("正在进入评教系统..."))
@@ -208,18 +207,14 @@ class JudgeThread(ProcessThread):
             self.error.emit(self.tr("未登录"), self.tr("请您先添加一个账户"))
             self.canceled.emit()
             return
-        # 依据当前的 session 重建 judge 对象
-        if self.session.has_login:
-            self.judge_ = AutoJudge(self.session)
         self.progressChanged.emit(0)
         try:
-            if self.choice == JudgeChoice.GET_COURSES:
-                if not self.session.has_login:
-                    result = self.login()
-                    if not result:
-                        self.canceled.emit()
-                        return
+            result = self.login()
+            if not result:
+                self.canceled.emit()
+                return
 
+            if self.choice == JudgeChoice.GET_COURSES:
                 self.messageChanged.emit(self.tr("正在获取未完成问卷信息..."))
                 self.progressChanged.emit(66)
                 if not self.can_run:
@@ -233,11 +228,6 @@ class JudgeThread(ProcessThread):
                 self.questionnaires.emit(questionnaires, questionnaires_finished)
                 self.hasFinished.emit()
             elif self.choice == JudgeChoice.JUDGE:
-                if not self.session.has_login:
-                    result = self.login()
-                    if not result:
-                        self.canceled.emit()
-                        return
                 result = self.judge()
                 if not result:
                     self.canceled.emit()
@@ -245,11 +235,6 @@ class JudgeThread(ProcessThread):
                 self.submitSuccess.emit()
                 self.hasFinished.emit()
             elif self.choice == JudgeChoice.EDIT:
-                if not self.session.has_login:
-                    result = self.login()
-                    if not result:
-                        self.canceled.emit()
-                        return
                 result = self.edit()
                 if not result:
                     self.canceled.emit()
@@ -257,11 +242,6 @@ class JudgeThread(ProcessThread):
                 self.editSuccess.emit()
                 self.hasFinished.emit()
             elif self.choice == JudgeChoice.JUDGE_ALL:
-                if not self.session.has_login:
-                    result = self.login()
-                    if not result:
-                        self.canceled.emit()
-                        return
                 result = self.judge_all()
                 if not result:
                     self.canceled.emit()

--- a/app/threads/JudgeThread.py
+++ b/app/threads/JudgeThread.py
@@ -6,6 +6,7 @@ from PyQt5.QtCore import pyqtSignal
 from .ProcessWidget import ProcessThread
 from ..sessions.jwxt_session import JWXTSession
 from ..utils import Account, logger, accounts
+from ..utils.mfa import MFACancelledError, MFAUnavailableError
 
 from jwxt import AutoJudge, QuestionnaireTemplate
 from auth import ServerError
@@ -50,7 +51,12 @@ class JudgeThread(ProcessThread):
     def login(self) -> bool:
         self.setIndeterminate.emit(True)
         self.messageChanged.emit(self.tr("正在登录教务系统..."))
-        self.session.login(self.account.username, self.account.password)
+        self.session.login(
+            self.account.username,
+            self.account.password,
+            account=self.account,
+            mfa_provider=self.account.session_manager.mfa_provider,
+        )
         self.session.has_login = True
 
         # 进入评教区域
@@ -264,6 +270,14 @@ class JudgeThread(ProcessThread):
                 self.hasFinished.emit()
             else:
                 raise ValueError(self.tr("未知选项"))
+        except MFACancelledError as e:
+            logger.info("MFA 验证已取消：%s", e)
+            self.error.emit(self.tr("安全验证已取消"), self.tr("已取消安全验证，本次操作未完成。"))
+            self.canceled.emit()
+        except MFAUnavailableError as e:
+            logger.error("MFA 交互不可用", exc_info=True)
+            self.error.emit(self.tr("登录问题"), str(e))
+            self.canceled.emit()
         except ServerError as e:
             logger.error("服务器错误", exc_info=True)
             if e.code == 102:

--- a/app/threads/LMSThread.py
+++ b/app/threads/LMSThread.py
@@ -40,13 +40,12 @@ class LMSThread(ProcessThread):
     def login(self):
         self.setIndeterminate.emit(True)
         self.messageChanged.emit(self.tr("正在登录思源学堂..."))
-        self.session.login(
+        self.session.ensure_login(
             accounts.current.username,
             accounts.current.password,
             account=accounts.current,
             mfa_provider=accounts.current.session_manager.mfa_provider,
         )
-        self.session.has_login = True
         if not self.can_run:
             return False
 
@@ -55,9 +54,6 @@ class LMSThread(ProcessThread):
         return True
 
     def _ensure_util(self) -> bool:
-        if self.session.has_login:
-            self.util = LMSUtil(self.session)
-            return True
         return self.login()
 
     def run(self):

--- a/app/threads/LMSThread.py
+++ b/app/threads/LMSThread.py
@@ -7,6 +7,7 @@ from auth import ServerError
 from lms import LMSUtil
 from .ProcessWidget import ProcessThread
 from ..utils import accounts, logger
+from ..utils.mfa import MFACancelledError, MFAUnavailableError
 
 
 class LMSAction(Enum):
@@ -39,7 +40,12 @@ class LMSThread(ProcessThread):
     def login(self):
         self.setIndeterminate.emit(True)
         self.messageChanged.emit(self.tr("正在登录思源学堂..."))
-        self.session.login(accounts.current.username, accounts.current.password)
+        self.session.login(
+            accounts.current.username,
+            accounts.current.password,
+            account=accounts.current,
+            mfa_provider=accounts.current.session_manager.mfa_provider,
+        )
         self.session.has_login = True
         if not self.can_run:
             return False
@@ -111,6 +117,14 @@ class LMSThread(ProcessThread):
             else:
                 raise ValueError(self.tr("未知的 LMS 操作"))
 
+        except MFACancelledError as e:
+            logger.info("MFA 验证已取消：%s", e)
+            self.error.emit(self.tr("安全验证已取消"), self.tr("已取消安全验证，本次操作未完成。"))
+            self.canceled.emit()
+        except MFAUnavailableError as e:
+            logger.error("MFA 交互不可用", exc_info=True)
+            self.error.emit(self.tr("登录问题"), str(e))
+            self.canceled.emit()
         except ServerError as e:
             logger.error("服务器错误", exc_info=True)
             if e.code == 102:

--- a/app/threads/LoginThreads.py
+++ b/app/threads/LoginThreads.py
@@ -1,4 +1,5 @@
-import json.decoder
+from __future__ import annotations
+
 from enum import Enum
 
 from requests import HTTPError
@@ -8,6 +9,7 @@ from auth import ServerError
 from PyQt5.QtCore import QThread, pyqtSignal
 
 from auth.new_login import NewLogin, LoginState
+from app.utils.mfa import MFACancelledError, MFAProvider, MFARequest, MFAUnavailableError
 from ywtb import YWTBLogin
 from ywtb.util import YWTBUtil
 
@@ -18,8 +20,6 @@ class LoginChoice(Enum):
     LOGIN = 2,
     GET_STUDENT_ID = 3
     FINISH_LOGIN = 4
-    MFA_SEND = 5
-    MFA_VERIFY = 6
 
 
 class LoginThread(QThread):
@@ -36,14 +36,16 @@ class LoginThread(QThread):
     loginSuccess = pyqtSignal()
     # 需要选择账户信号
     needChooseAccount = pyqtSignal()
-    # 需要 MFA 信号（数据：手机号）
-    needMFA = pyqtSignal(str)
-    # 发送验证码结果
-    sendMFAResult = pyqtSignal(bool, str)
-
     LoginChoice = LoginChoice
 
-    def __init__(self, choice: LoginChoice, username: str, password: str, captcha=None, parent=None):
+    def __init__(
+            self,
+            choice: LoginChoice,
+            username: str,
+            password: str,
+            captcha: str | None = None,
+            mfa_provider: MFAProvider | None = None,
+            parent=None):
         super().__init__(parent)
         self.choice = choice
         self.username = username
@@ -53,10 +55,8 @@ class LoginThread(QThread):
         self.login = None
         # 选择的账户类型
         self.accountType = None
-        # MFA Content
-        self._mfaContent = None
-        # MFA 验证码
-        self._mfaCode = None
+        # MFA 交互提供者
+        self.mfa_provider = mfa_provider
         # 是否信任当前客户端
         self.trustAgent = True
 
@@ -75,67 +75,26 @@ class LoginThread(QThread):
                 try:
                     # 检查账户是否存在多个身份
                     status, info = self.login.login(self.username, self.password, self.captcha or "", trust_agent=self.trustAgent)
+                    self._handle_login_status(status, info)
+                except (MFACancelledError, MFAUnavailableError) as e:
+                    logger.info("MFA 验证未完成：%s", e)
+                    self.loginFailed.emit(False, str(e))
                 except ServerError as e:
                     logger.error("服务器错误", exc_info=True)
                     self.loginFailed.emit(True, e.message)
-                else:
-                    if status == LoginState.SUCCESS:
-                        self.loginSuccess.emit()
-                    elif status == LoginState.REQUIRE_ACCOUNT_CHOICE:
-                        self.needChooseAccount.emit()
-                    elif status == LoginState.REQUIRE_MFA:
-                        self._mfaContent: NewLogin.MFAContext = info
-                        number = self._mfaContent.get_phone_number()
-                        self.needMFA.emit(number)
-                    elif status == LoginState.FAIL:
-                        logger.error("登录错误: \n%s", info)
-                        self.loginFailed.emit(True, info)
-                    else:
-                        raise ValueError("未知的登录状态")
-            elif self.choice == LoginChoice.MFA_VERIFY:
-                try:
-                    if self._mfaContent is None:
-                        raise ValueError("MFA 内容未设置")
-                    if self._mfaCode is None:
-                        raise ValueError("MFA 验证码未设置")
-                    self._mfaContent.verify_phone_code(self._mfaCode)
-                    status, info = self.login.login(trust_agent=self.trustAgent)
-                except ServerError as e:
-                    logger.error("服务器错误", exc_info=True)
-                    self.loginFailed.emit(True, e.message)
-                else:
-                    if status == LoginState.SUCCESS:
-                        self.loginSuccess.emit()
-                    elif status == LoginState.REQUIRE_ACCOUNT_CHOICE:
-                        self.needChooseAccount.emit()
-                    elif status == LoginState.FAIL:
-                        logger.error("登录错误: \n%s", info)
-                        self.loginFailed.emit(True, info)
-                    else:
-                        logger.error("登录错误：%s\n%s", status, info)
-                        raise ValueError("未知的登录状态")
-
-            elif self.choice == LoginChoice.MFA_SEND:
-                try:
-                    if self._mfaContent is None:
-                        raise ValueError("MFA 内容未设置")
-                    self._mfaContent.send_verify_code()
-                except (ServerError, HTTPError, json.decoder.JSONDecodeError) as e:
-                    logger.error("发送验证码时发生错误", exc_info=True)
-                    self.sendMFAResult.emit(False, str(e))
-                else:
-                    self.sendMFAResult.emit(True, "")
 
             elif self.choice == LoginChoice.FINISH_LOGIN:
                 try:
                     if self.accountType is None:
                         raise ValueError("必须选择账户类型")
-                    self.login.login(account_type=self.accountType, trust_agent=self.trustAgent)
+                    status, info = self.login.login(account_type=self.accountType, trust_agent=self.trustAgent)
+                    self._handle_login_status(status, info)
+                except (MFACancelledError, MFAUnavailableError) as e:
+                    logger.info("MFA 验证未完成：%s", e)
+                    self.loginFailed.emit(False, str(e))
                 except ServerError as e:
                     logger.error("服务器错误", exc_info=True)
                     self.loginFailed.emit(False, e.message)
-                else:
-                    self.loginSuccess.emit()
             elif self.choice == LoginChoice.GET_STUDENT_ID:
                 try:
                     ywtb_util = YWTBUtil(self.login.session)
@@ -162,3 +121,42 @@ class LoginThread(QThread):
         except Exception as e:
             logger.error("其他错误", exc_info=True)
             self.loginFailed.emit(False, str(e))
+
+    def _handle_login_status(self, status: LoginState, info: NewLogin.MFAContext | object | None) -> None:
+        """
+        处理 NewLogin 状态机返回的登录状态。
+        """
+        while True:
+            if status == LoginState.SUCCESS:
+                self.loginSuccess.emit()
+                return
+
+            if status == LoginState.REQUIRE_ACCOUNT_CHOICE:
+                self.needChooseAccount.emit()
+                return
+
+            if status == LoginState.REQUIRE_MFA:
+                if not isinstance(info, NewLogin.MFAContext):
+                    raise ServerError(500, "服务器返回了无法识别的 MFA 上下文。")
+                if self.mfa_provider is None:
+                    raise MFAUnavailableError("登录需要 MFA 验证，但当前没有可用的 MFA 交互提供者。")
+                phone_number = info.get_phone_number()
+                request = MFARequest(
+                    # 登录时还没有账户 UUID，所以先用一个固定值占位，等 MFA 验证完成后再更新为实际的账户 UUID
+                    account_uuid="login-draft",
+                    # 登录时同样还没有账户名称；采用用户输入的用户名占位。
+                    account_name=self.username,
+                    site_key="account-login",
+                    site_name="统一身份认证",
+                    phone_number=phone_number,
+                )
+                self.trustAgent = self.mfa_provider.handle(info, request)
+                status, info = self.login.login(trust_agent=self.trustAgent)
+                continue
+
+            if status == LoginState.FAIL:
+                logger.error("登录错误: \n%s", info)
+                self.loginFailed.emit(True, str(info))
+                return
+
+            raise ValueError("未知的登录状态")

--- a/app/threads/ScheduleAttendanceThread.py
+++ b/app/threads/ScheduleAttendanceThread.py
@@ -11,6 +11,7 @@ from auth import ServerError
 from .ProcessWidget import ProcessThread
 from ..sessions.attendance_session import AttendanceSession
 from ..utils import accounts, logger, cfg
+from ..utils.mfa import MFACancelledError, MFAUnavailableError
 
 
 class AttendanceFlowLogin(Enum):
@@ -47,7 +48,13 @@ class ScheduleAttendanceThread(ProcessThread):
         """
         self.setIndeterminate.emit(True)
         self.messageChanged.emit(self.tr("正在通过 WebVPN 登录考勤系统..."))
-        self.session.webvpn_login(accounts.current.username, accounts.current.password, is_postgraduate=accounts.current.type == accounts.current.POSTGRADUATE)
+        self.session.webvpn_login(
+            accounts.current.username,
+            accounts.current.password,
+            is_postgraduate=accounts.current.type == accounts.current.POSTGRADUATE,
+            account=accounts.current,
+            mfa_provider=accounts.current.session_manager.mfa_provider,
+        )
         self.messageChanged.emit(self.tr("登录 WebVPN 成功。"))
 
     def normal_login(self):
@@ -56,7 +63,13 @@ class ScheduleAttendanceThread(ProcessThread):
         """
         self.setIndeterminate.emit(True)
         self.messageChanged.emit(self.tr("正在直接登录考勤系统..."))
-        self.session.login(accounts.current.username, accounts.current.password, is_postgraduate=accounts.current.type == accounts.current.POSTGRADUATE)
+        self.session.login(
+            accounts.current.username,
+            accounts.current.password,
+            is_postgraduate=accounts.current.type == accounts.current.POSTGRADUATE,
+            account=accounts.current,
+            mfa_provider=accounts.current.session_manager.mfa_provider,
+        )
         self.messageChanged.emit(self.tr("直接登录考勤系统成功。"))
 
     def run(self):
@@ -142,6 +155,14 @@ class ScheduleAttendanceThread(ProcessThread):
             self.records = records
             self.progressChanged.emit(100)
 
+        except MFACancelledError as e:
+            logger.info("MFA 验证已取消：%s", e)
+            self.error.emit(self.tr("安全验证已取消"), self.tr("已取消安全验证，本次操作未完成。"))
+            self.canceled.emit()
+        except MFAUnavailableError as e:
+            logger.error("MFA 交互不可用", exc_info=True)
+            self.error.emit(self.tr("登录问题"), str(e))
+            self.canceled.emit()
         except ServerError as e:
             logger.error("服务器错误", exc_info=True)
             if e.code == 102:

--- a/app/threads/ScheduleAttendanceThread.py
+++ b/app/threads/ScheduleAttendanceThread.py
@@ -63,7 +63,7 @@ class ScheduleAttendanceThread(ProcessThread):
         """
         self.setIndeterminate.emit(True)
         self.messageChanged.emit(self.tr("正在直接登录考勤系统..."))
-        self.session.login(
+        self.session.ensure_login(
             accounts.current.username,
             accounts.current.password,
             is_postgraduate=accounts.current.type == accounts.current.POSTGRADUATE,
@@ -93,8 +93,8 @@ class ScheduleAttendanceThread(ProcessThread):
             return
 
         try:
-            # 如果当前账户已经登录，重建代理对象，防止出现 util 和 session 不对应的情况。
-            if self.session.has_login:
+            # 如果当前账户已经登录并且登录态仍有效，重建代理对象，防止 util 和 session 不对应。
+            if self.session.has_login and self.session.validate_login():
                 # 如果当前 session 已经登录，必须沿用当前登录方式。
                 self.login_method = AttendanceFlowLogin.NORMAL_LOGIN if self.session.login_method == self.session.LoginMethod.NORMAL else AttendanceFlowLogin.WEBVPN_LOGIN
                 self.util = Attendance(self.session, use_webvpn=self.login_method == AttendanceFlowLogin.WEBVPN_LOGIN, is_postgraduate=accounts.current.type == accounts.current.POSTGRADUATE)

--- a/app/threads/ScheduleThread.py
+++ b/app/threads/ScheduleThread.py
@@ -7,6 +7,7 @@ from .ProcessWidget import ProcessThread
 from ..sessions.jwxt_session import JWXTSession
 from ..utils import logger, cfg
 from ..utils.account import accounts
+from ..utils.mfa import MFACancelledError, MFAUnavailableError
 
 
 class ScheduleThread(ProcessThread):
@@ -41,7 +42,12 @@ class ScheduleThread(ProcessThread):
         """
         self.setIndeterminate.emit(True)
         self.messageChanged.emit(self.tr("正在登录教务系统..."))
-        self.session.login(accounts.current.username, accounts.current.password)
+        self.session.login(
+            accounts.current.username,
+            accounts.current.password,
+            account=accounts.current,
+            mfa_provider=accounts.current.session_manager.mfa_provider,
+        )
         self.session.has_login = True
         if not self.can_run:
             return False
@@ -86,6 +92,14 @@ class ScheduleThread(ProcessThread):
 
             self.progressChanged.emit(100)
 
+        except MFACancelledError as e:
+            logger.info("MFA 验证已取消：%s", e)
+            self.error.emit(self.tr("安全验证已取消"), self.tr("已取消安全验证，本次操作未完成。"))
+            self.canceled.emit()
+        except MFAUnavailableError as e:
+            logger.error("MFA 交互不可用", exc_info=True)
+            self.error.emit(self.tr("登录问题"), str(e))
+            self.canceled.emit()
         except ServerError as e:
             logger.error("服务器错误", exc_info=True)
             if e.code == 102:

--- a/app/threads/ScheduleThread.py
+++ b/app/threads/ScheduleThread.py
@@ -42,13 +42,12 @@ class ScheduleThread(ProcessThread):
         """
         self.setIndeterminate.emit(True)
         self.messageChanged.emit(self.tr("正在登录教务系统..."))
-        self.session.login(
+        self.session.ensure_login(
             accounts.current.username,
             accounts.current.password,
             account=accounts.current,
             mfa_provider=accounts.current.session_manager.mfa_provider,
         )
-        self.session.has_login = True
         if not self.can_run:
             return False
 
@@ -68,14 +67,10 @@ class ScheduleThread(ProcessThread):
             return
 
         try:
-            # 如果当前账户已经登录，重建代理对象，防止出现 util 和 session 不对应的情况。
-            if self.session.has_login:
-                self.util = Schedule(self.session)
-            else:
-                result = self.login()
-                if not result:
-                    self.canceled.emit()
-                    return
+            result = self.login()
+            if not result:
+                self.canceled.emit()
+                return
 
             self.progressChanged.emit(66)
             self.messageChanged.emit("正在获取课表信息...")

--- a/app/threads/ScoreThread.py
+++ b/app/threads/ScoreThread.py
@@ -8,6 +8,7 @@ from jwxt.score import Score
 from ..sessions.jwxt_session import JWXTSession
 from ..threads.ProcessWidget import ProcessThread
 from ..utils import accounts, logger, cfg
+from ..utils.mfa import MFACancelledError, MFAUnavailableError
 from auth import ServerError
 
 
@@ -42,7 +43,12 @@ class ScoreThread(ProcessThread):
         """
         self.setIndeterminate.emit(True)
         self.messageChanged.emit(self.tr("正在登录教务系统..."))
-        self.session.login(accounts.current.username, accounts.current.password)
+        self.session.login(
+            accounts.current.username,
+            accounts.current.password,
+            account=accounts.current,
+            mfa_provider=accounts.current.session_manager.mfa_provider,
+        )
         self.session.has_login = True
         if not self.can_run:
             return False
@@ -105,6 +111,14 @@ class ScoreThread(ProcessThread):
                         result.append(course)
 
             self.progressChanged.emit(100)
+        except MFACancelledError as e:
+            logger.info("MFA 验证已取消：%s", e)
+            self.error.emit(self.tr("安全验证已取消"), self.tr("已取消安全验证，本次操作未完成。"))
+            self.canceled.emit()
+        except MFAUnavailableError as e:
+            logger.error("MFA 交互不可用", exc_info=True)
+            self.error.emit(self.tr("登录问题"), str(e))
+            self.canceled.emit()
         except ServerError as e:
             logger.error("服务器错误", exc_info=True)
             if e.code == 102:

--- a/app/threads/ScoreThread.py
+++ b/app/threads/ScoreThread.py
@@ -43,13 +43,12 @@ class ScoreThread(ProcessThread):
         """
         self.setIndeterminate.emit(True)
         self.messageChanged.emit(self.tr("正在登录教务系统..."))
-        self.session.login(
+        self.session.ensure_login(
             accounts.current.username,
             accounts.current.password,
             account=accounts.current,
             mfa_provider=accounts.current.session_manager.mfa_provider,
         )
-        self.session.has_login = True
         if not self.can_run:
             return False
 
@@ -75,14 +74,10 @@ class ScoreThread(ProcessThread):
         self.progressChanged.emit(0)
 
         try:
-            # 如果当前账户已经登录，重建代理对象，防止出现 util 和 session 不对应的情况。
-            if self.session.has_login:
-                self.util = Score(self.session)
-            else:
-                result = self.login()
-                if not result:
-                    self.canceled.emit()
-                    return
+            result = self.login()
+            if not result:
+                self.canceled.emit()
+                return
             self.progressChanged.emit(66)
             self.messageChanged.emit("正在获取成绩...")
             if not self.can_run:

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -6,6 +6,8 @@ from .style_sheet import StyleSheet, Color
 from .icons import MyFluentIcon
 from .log import logger, get_logger
 from .single_app import SingleApplication
+from .mfa import MFAAction, MFAActionType, MFACancelledError, MFAProvider, MFARequest, MFAUnavailableError
+from .qt_mfa import QtMFAProvider
 from .linux_compat import apply_linux_env_patches, apply_linux_keyring_patches
 from .migrate_data import migrate_account, migrate_config, migrate_all, migrate_data, migrate_log, \
     APP_NAME, LOG_DIRECTORY, DATA_DIRECTORY, CACHE_DIRECTORY

--- a/app/utils/interactive_login.py
+++ b/app/utils/interactive_login.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from auth import ServerError
+from auth.new_login import LoginState, NewLogin
+
+from app.utils.account import Account
+from app.utils.mfa import MFAProvider, MFARequest, MFAUnavailableError
+
+
+def login_with_optional_mfa(
+        login_util: NewLogin,
+        username: str,
+        password: str,
+        account: Account | None,
+        mfa_provider: MFAProvider | None,
+        account_type: NewLogin.AccountType = NewLogin.POSTGRADUATE,
+        site_key: str = "",
+        site_name: str = "",
+        jcaptcha: str = "",
+        trust_agent: bool = True) -> None:
+    """
+    执行统一认证登录，并在需要 MFA 时通过应用层 provider 原地完成验证。
+
+    该函数对于各种登录情况的处理逻辑如下：
+    LoginState.SUCCESS: 直接返回，登录成功。
+    LoginState.FAIL: 抛出 ServerError，message 包含登录失败的原因。
+    LoginState.REQUIRE_CAPTCHA: 抛出 ServerError，message 提示需要验证码，不处理
+    LoginState.REQUIRE_ACCOUNT_CHOICE: 重新调用 login_util.login() 让用户选择账户后继续登录流程。
+    LoginState.REQUIRE_MFA: 通过给出的 mfa_provider 完成两步验证流程，完成后继续登录流程。
+
+    简单来讲，就是只处理“服务端要求两步验证”这一种异常情况，不处理其他任何异常情况。
+    """
+    current_trust_agent = trust_agent
+    status, info = login_util.login(
+        username,
+        password,
+        jcaptcha,
+        account_type=account_type,
+        trust_agent=current_trust_agent,
+    )
+
+    while True:
+        if status == LoginState.SUCCESS:
+            return
+
+        if status == LoginState.FAIL:
+            raise ServerError(100, f"登录失败: {info}")
+
+        if status == LoginState.REQUIRE_CAPTCHA:
+            raise ServerError(101, "登录需要验证码。")
+
+        if status == LoginState.REQUIRE_ACCOUNT_CHOICE:
+            status, info = login_util.login(account_type=account_type, trust_agent=current_trust_agent)
+            continue
+
+        if status == LoginState.REQUIRE_MFA:
+            if not isinstance(info, NewLogin.MFAContext):
+                raise ServerError(500, "服务器返回了无法识别的 MFA 上下文。")
+            if mfa_provider is None:
+                raise MFAUnavailableError("登录需要 MFA 验证，但当前没有可用的 MFA 交互提供者。")
+
+            phone_number = info.get_phone_number()
+            request = _build_mfa_request(account, username, site_key, site_name, phone_number)
+            current_trust_agent = mfa_provider.handle(info, request)
+            status, info = login_util.login(trust_agent=current_trust_agent)
+            continue
+
+        raise ServerError(500, "未知的登录状态。")
+
+
+def _build_mfa_request(
+        account: Account | None,
+        fallback_account_name: str,
+        site_key: str,
+        site_name: str,
+        phone_number: str) -> MFARequest:
+    """
+    根据账户与站点信息构造应用层 MFA 请求上下文。
+    """
+    # 默认情况下，如果没有账户信息，就用一些固定值占位，等 MFA 验证完成后再更新为实际的账户 UUID 和账户名称
+    if account is None:
+        account_uuid = "login-draft"
+        account_name = fallback_account_name
+    else:
+        account_uuid = account.uuid
+        account_name = account.nickname or account.username
+
+    return MFARequest(
+        account_uuid=account_uuid,
+        account_name=account_name,
+        site_key=site_key,
+        site_name=site_name or site_key or "统一身份认证",
+        phone_number=phone_number,
+    )

--- a/app/utils/mfa.py
+++ b/app/utils/mfa.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Protocol
+
+from auth.new_login import NewLogin
+
+
+class MFAActionType(Enum):
+    """
+    MFA 对话框向业务线程返回的用户动作类型。
+    """
+    # 用户要求发送手机验证码
+    SEND_CODE = "send_code"
+    # 用户要求输入验证码并验证
+    VERIFY_CODE = "verify_code"
+    # 用户要求取消 MFA 验证
+    CANCEL = "cancel"
+
+
+@dataclass(frozen=True)
+class MFARequest:
+    """
+    一次应用层 MFA 请求的展示上下文。
+    """
+    # 登录账户的 uuid
+    account_uuid: str
+    # 登录账户的名称
+    account_name: str
+    # 登录目标网站的一个标识符。同一网站的不同 MFA 场景可以使用同一个 site_key。
+    site_key: str
+    # 登录目标网站的名称，用于在 MFA 对话框中提示用户。
+    site_name: str
+    # 需要验证的电话号码，只用于展示。
+    phone_number: str
+
+
+@dataclass(frozen=True)
+class MFAAction:
+    """
+    用户在 MFA 对话框中触发的一次动作。
+    """
+    # 用户动作的类型
+    type: MFAActionType
+    # 当 type 是 VERIFY_CODE 时，用户输入的验证码；其他类型时忽略。
+    code: str = ""
+    # 当 type 是 VERIFY_CODE 时，用户是否选择信任当前客户端；其他类型时忽略。
+    trust_agent: bool = True
+
+
+class MFACancelledError(Exception):
+    """
+    用户取消 MFA 验证。
+    """
+
+
+class MFAUnavailableError(Exception):
+    """
+    当前环境没有可用的 MFA 交互提供者。
+    """
+
+
+class MFAProvider(Protocol):
+    """
+    应用层 MFA 交互提供者接口。
+    """
+
+    def handle(self, context: NewLogin.MFAContext, request: MFARequest) -> bool:
+        """
+        处理一次 MFA 交互，并返回用户是否选择信任当前客户端。
+        """
+
+    def report_send_result(self, request: MFARequest, success: bool, message: str = "") -> None:
+        """
+        向 UI 报告验证码发送结果。
+        """

--- a/app/utils/qt_mfa.py
+++ b/app/utils/qt_mfa.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import queue
+import threading
+
+from PyQt5.QtCore import QObject, pyqtSignal, pyqtSlot
+
+from app.utils.mfa import MFAAction, MFAActionType, MFACancelledError, MFARequest
+from auth.new_login import NewLogin
+
+
+class QtMFAProvider(QObject):
+    """
+    通过 Qt 信号把业务线程中的 MFA 请求转交给主线程对话框处理。
+    """
+    # 在开始处理请求时，发送 MFARequest 对象。
+    requestMFA = pyqtSignal(object)
+    # 在发送验证码后，返回服务端给出的验证码发送情况。格式为 (MFARequest, success: bool, message: str)
+    sendResult = pyqtSignal(object, bool, str)
+
+    def __init__(self, parent: QObject | None = None) -> None:
+        """
+        创建 Qt MFA 交互提供者。
+        """
+        super().__init__(parent)
+        # 同时只能显示一个请求两步验证的对话框
+        self._dialog_lock = threading.Lock()
+        self._state_lock = threading.Lock()
+        self._active_queue: queue.Queue[MFAAction] | None = None
+        self._active_request: MFARequest | None = None
+
+    def handle(self, context: NewLogin.MFAContext, request: MFARequest) -> bool:
+        """
+        显示 MFA 对话框，并在当前业务线程中处理发送验证码与验证验证码。
+        """
+        with self._dialog_lock:
+            action_queue: queue.Queue[MFAAction] = queue.Queue()
+            with self._state_lock:
+                self._active_queue = action_queue
+                self._active_request = request
+
+            self.requestMFA.emit(request)
+            try:
+                while True:
+                    action = action_queue.get()
+                    if action.type == MFAActionType.CANCEL:
+                        raise MFACancelledError("已取消安全验证。")
+
+                    if action.type == MFAActionType.SEND_CODE:
+                        self._send_code(context, request)
+                        continue
+
+                    if action.type == MFAActionType.VERIFY_CODE:
+                        context.verify_phone_code(action.code)
+                        return action.trust_agent
+            finally:
+                with self._state_lock:
+                    if self._active_queue is action_queue:
+                        self._active_queue = None
+                        self._active_request = None
+
+    def report_send_result(self, request: MFARequest, success: bool, message: str = "") -> None:
+        """
+        向主线程报告验证码发送结果。
+        """
+        self.sendResult.emit(request, success, message)
+
+    @pyqtSlot(object)
+    def submit_action(self, action: MFAAction) -> None:
+        """
+        接收主线程 UI 提交的 MFA 用户动作。
+        """
+        with self._state_lock:
+            action_queue = self._active_queue
+        if action_queue is not None:
+            action_queue.put(action)
+
+    def _send_code(self, context: NewLogin.MFAContext, request: MFARequest) -> None:
+        """
+        在业务线程中发送验证码，并把结果反馈给 UI。
+        """
+        try:
+            context.send_verify_code()
+        except Exception as exc:
+            self.report_send_result(request, False, str(exc))
+        else:
+            self.report_send_result(request, True, "")

--- a/app/utils/session_manager.py
+++ b/app/utils/session_manager.py
@@ -6,6 +6,7 @@ from app.sessions.session_backend import AccessMode, SessionBackend
 
 if TYPE_CHECKING:
     from app.sessions.common_session import CommonLoginSession
+    from app.utils.mfa import MFAProvider
 
 
 class SessionManager:
@@ -27,6 +28,7 @@ class SessionManager:
             AccessMode.NORMAL: SessionBackend(AccessMode.NORMAL),
             AccessMode.WEBVPN: SessionBackend(AccessMode.WEBVPN),
         }
+        self.mfa_provider: MFAProvider | None = None
 
     def register(self, class_: type[CommonLoginSession], name: str, allow_override: bool = True) -> None:
         """
@@ -102,6 +104,12 @@ class SessionManager:
     def get_backend(self, access_mode: AccessMode) -> SessionBackend:
         """获取指定访问方式对应的共享后端。"""
         return self.backends[access_mode]
+
+    def set_mfa_provider(self, provider: MFAProvider | None) -> None:
+        """
+        设置当前账号会话管理器使用的 MFA 交互提供者。
+        """
+        self.mfa_provider = provider
 
     def _create_session(self, class_: type[CommonLoginSession]) -> CommonLoginSession:
         """创建一个站点 Session 适配器实例。"""

--- a/app/utils/session_manager.py
+++ b/app/utils/session_manager.py
@@ -1,3 +1,13 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from app.sessions.session_backend import AccessMode, SessionBackend
+
+if TYPE_CHECKING:
+    from app.sessions.common_session import CommonLoginSession
+
+
 class SessionManager:
     """
     SessionManager 保存此应用程序访问的所有网站的 session。
@@ -5,16 +15,20 @@ class SessionManager:
     程序使用的任何需要登录的网站的 session 都应当被保存在此处。
     """
     # 类变量，用于存放全局注册的 session 类
-    sessions = {}
+    sessions: dict[str, type[CommonLoginSession]] = {}
 
-    def __init__(self):
+    def __init__(self) -> None:
         """
         创建一个 session 管理器
         """
-        self.sessions = {}
-        self.instances = {}
+        self.sessions: dict[str, type[CommonLoginSession]] = {}
+        self.instances: dict[str, CommonLoginSession | None] = {}
+        self.backends = {
+            AccessMode.NORMAL: SessionBackend(AccessMode.NORMAL),
+            AccessMode.WEBVPN: SessionBackend(AccessMode.WEBVPN),
+        }
 
-    def register(self, class_, name: str, allow_override=True) -> None:
+    def register(self, class_: type[CommonLoginSession], name: str, allow_override: bool = True) -> None:
         """
         注册一个 session 类。注册后，就可以通过 get_session 方法获得这个 session 类的实例。
         :param allow_override: 是否允许覆盖同名已经注册的 session
@@ -28,7 +42,7 @@ class SessionManager:
         self.instances[name] = None
 
     @classmethod
-    def global_register(cls, class_, name: str, allow_override=True) -> None:
+    def global_register(cls, class_: type[CommonLoginSession], name: str, allow_override: bool = True) -> None:
         """
         全局注册一个 session 类。注册后，可以在此类的任何一个实例中访问此 session 类。
         不要在全局级别和实例级别同时注册同一个 session 类，否则可能出现诡异的问题。
@@ -55,7 +69,7 @@ class SessionManager:
         """
         return name in self.instances and self.instances[name] is not None
 
-    def rename(self, old_name: str, new_name: str, allow_override=True) -> None:
+    def rename(self, old_name: str, new_name: str, allow_override: bool = True) -> None:
         """
         重命名一个已经注册的 session 类的名称。请注意，全局注册的 session 名称无法被修改。
         :param old_name: 类注册时填入的名称
@@ -70,7 +84,7 @@ class SessionManager:
         self.sessions[new_name] = self.sessions.pop(old_name)
         self.instances[new_name] = self.instances.pop(old_name)
 
-    def get_session(self, name: str):
+    def get_session(self, name: str) -> CommonLoginSession:
         """
         获取一个名称为 name 的 session 类的实例
         :param name: session 的名称
@@ -80,7 +94,18 @@ class SessionManager:
         # 由于此类的类变量和成员变量不互通，因此需要判断从类变量还是成员变量中取出 session 类
         if name not in self.instances or self.instances[name] is None:
             if name in self.sessions:
-                self.instances[name] = self.sessions[name]()
+                self.instances[name] = self._create_session(self.sessions[name])
             else:
-                self.instances[name] = self.__class__.sessions[name]()
+                self.instances[name] = self._create_session(self.__class__.sessions[name])
         return self.instances[name]
+
+    def get_backend(self, access_mode: AccessMode) -> SessionBackend:
+        """获取指定访问方式对应的共享后端。"""
+        return self.backends[access_mode]
+
+    def _create_session(self, class_: type[CommonLoginSession]) -> CommonLoginSession:
+        """创建一个站点 Session 适配器实例。"""
+        backend = self.backends[class_.default_access_mode]
+        if class_.supports_webvpn:
+            return class_(backend=backend, webvpn_backend=self.backends[AccessMode.WEBVPN])
+        return class_(backend=backend)

--- a/auth/__init__.py
+++ b/auth/__init__.py
@@ -3,5 +3,5 @@
 # 功能包含：登录、WebVPN 登录、WebVPN 网址与正常网址互转
 
 from .util import get_timestamp, getVPNUrl, getOrdinaryUrl, getPlaintext, getCiphertext, get_session, ServerError, generate_fp_visitor_id
-from .new_login import LoginState, NewLogin, NewWebVPNLogin, extract_account_choices, extract_alert_message, extract_execution_value, extract_mfa_enabled
+from .new_login import LoginState, NewLogin, NewWebVPNLogin, extract_account_choices, extract_alert_message, extract_execution_value, extract_mfa_enabled, is_safety_verify_page
 from .constant import *

--- a/auth/constant.py
+++ b/auth/constant.py
@@ -7,7 +7,7 @@ JWXT_LOGIN_URL = "https://jwxt.xjtu.edu.cn/jwapp/sys/homeapp/index.do"
 # webvpn 登录地址
 WEBVPN_LOGIN_URL = "https://webvpn.xjtu.edu.cn/login?cas_login=true"
 # 思源学堂（新版）登录地址
-LMS_LOGIN_URL = "lms.xjtu.edu.cn"
+LMS_LOGIN_URL = "https://lms.xjtu.edu.cn"
 # 本科生考勤系统登录地址
 ATTENDANCE_URL = "https://org.xjtu.edu.cn/openplatform/oauth/authorize?appId=1372&redirectUri=https://bkkq.xjtu.edu.cn/berserker-auth/auth/attendance-pc/casReturn&responseType=code&scope=user_info&state=1234"
 ATTENDANCE_WEBVPN_URL = "http://bkkq.xjtu.edu.cn"

--- a/auth/new_login.py
+++ b/auth/new_login.py
@@ -6,6 +6,7 @@ import enum
 import json
 import re
 
+import requests
 from Crypto.PublicKey import RSA
 from Crypto.Cipher import PKCS1_v1_5
 from lxml import html
@@ -216,6 +217,9 @@ class NewLogin:
         self.post_url = response.url
         # 获得 execution 字段
         self.execution_input = extract_execution_value(response.text)
+        self._already_authenticated_response: requests.Response | None = None
+        if self.execution_input is None and "/cas/login" not in response.url:
+            self._already_authenticated_response = response
         # 获得一个标识符
         self.fp_visitor_id = visitor_id if visitor_id is not None else generate_fp_visitor_id()
         # 是否进行 mfa 验证
@@ -287,6 +291,13 @@ class NewLogin:
                  - (LoginState.REQUIRE_ACCOUNT_CHOICE, choices): 需要选择账户，附带账户选项列表。
         :raises RuntimeError: 如果已经登录过一次，则抛出此异常。请重新创建 NewLogin 对象以登录其他账号。
         """
+        if self._already_authenticated_response is not None:
+            authenticated_response = self._already_authenticated_response
+            self._already_authenticated_response = None
+            self.has_login = True
+            self.postLogin(authenticated_response)
+            return LoginState.SUCCESS, self.session
+
         # 如果需要选择账户，则执行账户选择逻辑
         if self._choose_account_response:
             return self._finish_account_choice(account_type)

--- a/auth/new_login.py
+++ b/auth/new_login.py
@@ -1,6 +1,7 @@
 # 此文件实现了 2025 年 7 月 17 日后西安交通大学新统一认证系统的登录，即 login.xjtu.edu.cn。
-# 服务端部分处理尚不稳定，因此此文件中提供的 API 也不稳定，在后续版本中可能出现函数名更改/参数更改等情况。
-# 此文件会尽可能与登录页面前端实现保持一致，不会尝试利用设计漏洞等方式绕过验证码等安全措施。
+# 此文件会尽可能与登录页面前端实现保持一致，不会尝试利用设计漏洞等方式绕过验证码、两步验证等安全措施。
+from __future__ import annotations
+
 import base64
 import enum
 import json
@@ -17,14 +18,50 @@ from .util import get_session, ServerError, generate_fp_visitor_id, getVPNUrl
 
 
 # 使用 lxml 解析 HTML 并提取表单中的 execution 值
-def extract_execution_value(html_content):
+def extract_execution_value(html_content: str) -> Optional[str]:
     """从 HTML 内容中提取 name=execution 的 input 元素的 value"""
     tree = html.fromstring(html_content)
     execution_input = tree.xpath('//input[@name="execution"]/@value')
     return execution_input[0] if execution_input else None
 
 
-def extract_account_choices(html_content):
+def extract_input_value(html_content: str, name: str) -> Optional[str]:
+    """
+    从 HTML 内容中提取指定 input 元素的 value。
+    :param html_content: HTML 文本
+    :param name: input 元素的 name 属性
+    :return: input 元素的 value，未找到时返回 None
+    """
+    tree = html.fromstring(html_content)
+    input_value = tree.xpath(f'//input[@name="{name}"]/@value')
+    return input_value[0] if input_value else None
+
+
+def is_safety_verify_page(html_content: str) -> bool:
+    """
+    判断 HTML 内容是否为统一认证返回的 Safety Verify 二次认证页面。
+    :param html_content: HTML 文本
+    :return: 如果页面符合 Safety Verify 的结构特征则返回 True
+    """
+    try:
+        tree = html.fromstring(html_content)
+    except (ValueError, html.ParserError):
+        return False
+
+    title = tree.xpath('string(//title)')
+    has_safety_title = "Safety Verify" in title
+    has_verify_form = bool(tree.xpath('//*[@id="fm1"]//input[@name="secState"]/@value'))
+    has_execution = bool(tree.xpath('//*[@id="fm1"]//input[@name="execution"]/@value'))
+    has_submit_event = bool(tree.xpath('//*[@id="fm1"]//input[@name="_eventId"]/@value'))
+    has_sec_init_api = "/cas/sec/initByType" in html_content or "\\/cas\\/sec\\/initByType" in html_content
+    has_safety_text = "选择安全认证" in html_content or "二次认证" in html_content
+
+    return has_verify_form and has_execution and has_submit_event and (
+        has_safety_title or has_sec_init_api or has_safety_text
+    )
+
+
+def extract_account_choices(html_content: str) -> Optional[list[dict[str, str]]]:
     """
     从账户选择页面中提取账户选项信息
     Args:
@@ -60,7 +97,7 @@ def extract_account_choices(html_content):
     return account_choices if account_choices else None
 
 
-def extract_alert_message(html_content):
+def extract_alert_message(html_content: str) -> Optional[dict[str, str | bool]]:
     """
     提取 el-alert 组件的错误信息
     Args:
@@ -139,13 +176,26 @@ class NewLogin:
         UNDERGRADUATE = 0
         POSTGRADUATE = 1
 
+    class MFAFlow(enum.Enum):
+        """
+        MFA 验证流程类型。
+        """
+        MFA_DETECT = "mfa"
+        SAFETY_VERIFY = "sec"
+
     class MFAContext:
-        def __init__(self, new_login_instance, state, required=True):
+        def __init__(
+                self,
+                new_login_instance: NewLogin,
+                state: str,
+                required: bool = True,
+                flow: Optional[NewLogin.MFAFlow] = None):
             self._new_login = new_login_instance
             self.state = state
-            self.gid = None
+            self.gid: Optional[str] = None
             self.required = required
-            self._phone_number = None
+            self.flow = flow if flow is not None else new_login_instance.MFAFlow.MFA_DETECT
+            self._phone_number: Optional[str] = None
 
         def get_phone_number(self) -> str:
             """
@@ -155,7 +205,7 @@ class NewLogin:
             if self._phone_number is not None:
                 return self._phone_number
 
-            data = self._new_login._get("https://login.xjtu.edu.cn/cas/mfa/initByType/securephone",
+            data = self._new_login._get(f"https://login.xjtu.edu.cn/cas/{self.flow.value}/initByType/securephone",
                                         params={"state": self.state})
             data.raise_for_status()
             json_result = data.json()
@@ -180,7 +230,7 @@ class NewLogin:
             else:
                 raise ServerError(json_result["code"], json_result["message"])
 
-        def verify_phone_code(self, code: str):
+        def verify_phone_code(self, code: str) -> None:
             """
             在登录系统要求两步验证且发送了登录验证码后，向系统核对验证码。
             :param code: 收到的验证码
@@ -194,6 +244,11 @@ class NewLogin:
             json_result = data.json()
             if json_result["code"] != 0:
                 raise ServerError(json_result["code"], json_result["message"])
+            result_data = json_result.get("data")
+            if isinstance(result_data, dict):
+                status = result_data.get("status")
+                if status is not None and status not in (2, "2"):
+                    raise ServerError(500, json_result.get("message") or "验证码验证失败。")
 
     UNDERGRADUATE = AccountType.UNDERGRADUATE
     POSTGRADUATE = AccountType.POSTGRADUATE
@@ -232,6 +287,8 @@ class NewLogin:
         self.has_login = False
         # 保存 checkForBothAccounts 方法可能获得的响应
         self._choose_account_response = None
+        # 保存 Safety Verify 二次认证页面响应
+        self._safety_verify_response: Optional[requests.Response] = None
         # 两步验证上下文
         self.mfa_context: Optional[NewLogin.MFAContext] = None
         # 登录凭据
@@ -302,6 +359,10 @@ class NewLogin:
         if self._choose_account_response:
             return self._finish_account_choice(account_type)
 
+        # 如果前一次登录 POST 返回了 Safety Verify 页面，则在 MFA 认证后提交该页面的隐藏表单。
+        if self._safety_verify_response is not None:
+            return self._finish_safety_verify()
+
         if self.has_login:
             raise RuntimeError("已经登录，不能重复登录。请重新创建 NewLogin 对象以登录其他账号。")
 
@@ -333,7 +394,12 @@ class NewLogin:
 
             state = data["data"]["state"]
             need = data["data"]["need"]
-            self.mfa_context = self.MFAContext(self, state, required=bool(need))
+            self.mfa_context = self.MFAContext(
+                self,
+                state,
+                required=bool(need),
+                flow=self.MFAFlow.MFA_DETECT,
+            )
 
             if need:
                 return LoginState.REQUIRE_MFA, self.mfa_context
@@ -359,6 +425,15 @@ class NewLogin:
                                           "geolocation": "",
                                           "trustAgent": trust_agent}, allow_redirects=True)
 
+        return self._process_login_response(login_response)
+
+    def _process_login_response(self, login_response: requests.Response) -> Tuple[LoginState, Union[
+        MFAContext, object, None]]:
+        """
+        处理登录流程中的 POST 响应，并将其转换为状态机结果。
+        :param login_response: 登录或后续认证提交返回的响应
+        :return: 登录状态和对应的附带信息
+        """
         if login_response.status_code == 401:
             self.fail_count += 1
             return LoginState.FAIL, "登录失败，用户名或密码错误。"
@@ -368,6 +443,21 @@ class NewLogin:
         if message:
             self.fail_count += 1
             return LoginState.FAIL, f"登录失败: {message['title']}"
+
+        if is_safety_verify_page(login_response.text):
+            sec_state = extract_input_value(login_response.text, "secState")
+            if sec_state is None:
+                raise ServerError(500, "服务器返回了二次认证页面，但页面中没有 secState 字段。")
+            self.fail_count = 0
+            self.has_login = False
+            self._safety_verify_response = login_response
+            self.mfa_context = self.MFAContext(
+                self,
+                sec_state,
+                required=True,
+                flow=self.MFAFlow.SAFETY_VERIFY,
+            )
+            return LoginState.REQUIRE_MFA, self.mfa_context
 
         self.fail_count = 0
         self.has_login = True
@@ -381,6 +471,39 @@ class NewLogin:
 
         self.postLogin(login_response)
         return LoginState.SUCCESS, self.session
+
+    def _finish_safety_verify(self) -> Tuple[LoginState, Union[MFAContext, object, None]]:
+        """
+        提交 Safety Verify 页面中的隐藏表单，以继续二次认证后的登录流程。
+        :return: 登录状态和对应的附带信息
+        """
+        if self._safety_verify_response is None:
+            raise RuntimeError("当前不需要完成 Safety Verify 二次认证。")
+
+        safety_response = self._safety_verify_response
+        sec_state = extract_input_value(safety_response.text, "secState")
+        execution = extract_execution_value(safety_response.text)
+        event_id = extract_input_value(safety_response.text, "_eventId") or "submit"
+        submit = extract_input_value(safety_response.text, "submit") or "Login1"
+
+        if sec_state is None or execution is None:
+            raise ServerError(500, "服务器返回的二次认证页面缺少必要的隐藏表单字段。")
+
+        verify_response = self._post(
+            safety_response.url,
+            data={
+                "secState": sec_state,
+                "execution": execution,
+                "_eventId": event_id,
+                "geolocation": "",
+                "fpVisitorId": self.fp_visitor_id,
+                "submit": submit,
+            },
+            allow_redirects=True,
+        )
+
+        self._safety_verify_response = None
+        return self._process_login_response(verify_response)
 
     def _finish_account_choice(self, account_type: AccountType, trust_agent=True):
         if not self._choose_account_response:


### PR DESCRIPTION
1. 由于现在登录后的凭证可以在学校多个系统间互通，合并了所有 session 实际后端，现在一个账户实际请求使用的 session 只会有两个：使用 webvpn 的和不使用 webvpn 的。
2. 适配学校新的两步验证：适配了正常登录后重定向到的两步验证界面。现在程序可以识别该页面的特征，要求用户通过验证码完成验证。
3. 修改两步验证界面逻辑：现在程序进行登录时，可以暂停登录，在任意界面弹出对话框请求两步验证，不再需要从账户界面重新登录账号验证。在验证成功后，当前登录将继续进行。