### PR TITLE
fix: Upgrade AUR deployment action to version 4.1.3

### DIFF
--- a/.github/workflows/update_aur.yml
+++ b/.github/workflows/update_aur.yml
@@ -85,7 +85,7 @@ jobs:
 
       # 4. 发布到三个不同的 AUR 仓库
       - name: Publish to AUR (xjtutoolbox)
-        uses: KSXGitHub/github-actions-deploy-aur@v3.0.1
+        uses: KSXGitHub/github-actions-deploy-aur@v4.1.3
         with:
           pkgname: xjtutoolbox
           pkgbuild: ./aur/xjtutoolbox/PKGBUILD
@@ -95,7 +95,7 @@ jobs:
           commit_message: "Auto-update to version ${{ env.TARGET_TAG }}"
 
       - name: Publish to AUR (xjtutoolbox-bin)
-        uses: KSXGitHub/github-actions-deploy-aur@v3.0.1
+        uses: KSXGitHub/github-actions-deploy-aur@v4.1.3
         with:
           pkgname: xjtutoolbox-bin
           pkgbuild: ./aur/xjtutoolbox-bin/PKGBUILD
@@ -105,7 +105,7 @@ jobs:
           commit_message: "Auto-update to version ${{ env.TARGET_TAG }}"
 
       - name: Publish to AUR (xjtutoolbox-git)
-        uses: KSXGitHub/github-actions-deploy-aur@v3.0.1
+        uses: KSXGitHub/github-actions-deploy-aur@v4.1.3
         with:
           pkgname: xjtutoolbox-git
           pkgbuild: ./aur/xjtutoolbox-git/PKGBUILD


### PR DESCRIPTION
### **Description / 描述**

此 Pull Request 旨在修复近期 GitHub Actions 工作流中出现的部署失败问题。旧版本的 AUR 部署 Action 在自动化构建和发布过程中抛出错误，导致流程中断。将其升级至 `v4.1.3` 后，解决了之前的执行报错，恢复了项目（如 XJTUToolBox）向 AUR 自动发布包和生成 `.SRCINFO` 文件的正常 CI/CD 流程。

### **Changes / 更改内容**

* 将工作流配置文件（例如 `.github/workflows` 目录下的 `.yml` 文件）中的 AUR deployment action 版本号安全升级至 `v4.1.3`。

### **Impact / 影响范围**

* 修复了持续集成流程，确保代码合并后能够成功触发并完成 AUR 仓库的更新。
* 此次更新不涉及核心业务代码逻辑的更改，仅影响自动化部署环节。

### **Checklist / 检查清单**

* [x] 已更新 GitHub Actions 配置文件中的 Action 版本号。
* [x] 已确认升级至 `v4.1.3` 后能够正常通过测试，无旧版报错，并能成功将更新推送到 AUR。