### PR TITLE
feat: LMS 批量下载功能

### DIFF
--- a/app/LMSInterface.py
+++ b/app/LMSInterface.py
@@ -1045,7 +1045,7 @@ class LMSInterface(ScrollArea):
     def onBatchDownloadRequested(self, selected_activities: list[dict]):
         """处理批量下载请求。
 
-        弹出对话框让用户选择，确认后获取活动详情、收集文件并启动批量下载。
+        弹出对话框让用户选择，确认后直接启动后台线程登录、收集文件并下载。
 
         :param selected_activities: 用户选中的活动字典列表。
         :return: 无返回值。
@@ -1059,7 +1059,6 @@ class LMSInterface(ScrollArea):
             if isinstance(a, dict) and str(a.get("type") or "") == activity_type
         )
 
-        # 弹对话框
         dialog = LMSBatchDownloadDialog(
             activity_type=activity_type,
             selected_activities=selected_activities,
@@ -1071,229 +1070,45 @@ class LMSInterface(ScrollArea):
         if dialog.exec() != QDialog.Accepted:
             return
 
-        # 登录
-        session, error = self.ensure_lms_login()
-        if session is None:
-            self.error(self.tr("未登录"), error or self.tr("请先添加一个账户"), parent=self)
+        current_account = accounts.current
+        if current_account is None:
+            self.error(self.tr("未登录"), self.tr("请先添加一个账户"), parent=self)
             return
 
-        util = self._get_lms_util()
-        if util is None:
-            self.error(self.tr("错误"), self.tr("无法获取 LMS 工具实例"), parent=self)
-            return
-
-        # 收集文件
-        files: list[tuple[str, str, str]] = []
-
-        for activity in selected_activities:
-            if not isinstance(activity, dict):
-                continue
-            activity_id = activity.get("id")
-            activity_title = str(activity.get("title") or "-")
-            safe_title = self.sanitize_filename(activity_title)
-            act_type = str(activity.get("type") or "")
-
-            detail = self._get_cached_activity_detail(activity_id, util)
-            if detail is None:
-                self.error(
-                    self.tr("跳过活动"),
-                    self.tr("无法获取「{0}」的详情，跳过").format(activity_title),
-                    parent=self,
-                )
-                continue
-
-            if act_type == ActivityType.HOMEWORK.value:
-                if dialog.download_uploads:
-                    self._collect_uploads(files, detail, safe_title, dialog, activity_title)
-                if dialog.download_submissions:
-                    self._collect_submission_uploads(
-                        files, detail, safe_title, dialog, activity_title, session, util
-                    )
-                if dialog.download_marked:
-                    self._collect_marked_attachments(
-                        files, detail, safe_title, dialog, activity_title, session, util
-                    )
-            elif act_type == ActivityType.MATERIAL.value:
-                self._collect_uploads(files, detail, safe_title, dialog, activity_title)
-            elif act_type == ActivityType.LESSON.value:
-                self._collect_replay_videos(files, detail, safe_title, dialog, activity_title)
-
-        if not files:
-            self.error(self.tr("无可下载文件"), self.tr("没有找到任何可下载的文件"), parent=self)
-            return
-
-        self._start_batch_download(files, session)
-
-    def _get_cached_activity_detail(self, activity_id: int, util) -> dict | None:
-        """获取活动的详细数据（含 uploads）。
-
-        优先使用缓存的活动列表数据（如果已有 uploads），
-        否则请求详情 API。
-        """
-        for one in self._current_activities:
-            if isinstance(one, dict) and one.get("id") == activity_id:
-                uploads = one.get("uploads")
-                if isinstance(uploads, list):
-                    return one
-                break
-
-        try:
-            detail = util.get_activity_detail(activity_id)
-            if isinstance(detail, dict):
-                return detail
-        except Exception:
-            pass
-        return None
-
-    @staticmethod
-    def _collect_uploads(
-        files: list, detail: dict, safe_title: str,
-        dialog: LMSBatchDownloadDialog, activity_title: str
-    ):
-        """收集活动附件。"""
-        uploads = detail.get("uploads", [])
-        if not isinstance(uploads, list):
-            return
-        for upload in uploads:
-            if not isinstance(upload, dict):
-                continue
-            url = upload.get("download_url") or upload.get("preview_url")
-            if not isinstance(url, str) or not url:
-                continue
-            file_name = str(upload.get("name") or "file")
-            file_label = f"{activity_title}_{file_name}"
-            output_path = LMSBatchDownloadThread._build_output_path(
-                file_name, safe_title, dialog.target_dir, dialog.layout_mode
-            )
-            files.append((url, output_path, file_label))
-
-    @staticmethod
-    def _collect_submission_uploads(
-        files: list, detail: dict, safe_title: str,
-        dialog: LMSBatchDownloadDialog, activity_title: str,
-        session, util
-    ):
-        """收集提交附件。"""
-        submission_list = detail.get("submission_list", {})
-        if not isinstance(submission_list, dict):
-            return
-        all_uploads: list[dict] = []
-        sub_uploads = submission_list.get("uploads")
-        if isinstance(sub_uploads, list):
-            all_uploads.extend(u for u in sub_uploads if isinstance(u, dict))
-        sub_items = submission_list.get("list")
-        if isinstance(sub_items, list):
-            for item in sub_items:
-                if not isinstance(item, dict):
-                    continue
-                item_uploads = item.get("uploads")
-                if isinstance(item_uploads, list):
-                    all_uploads.extend(u for u in item_uploads if isinstance(u, dict))
-        for upload in all_uploads:
-            url = upload.get("download_url") or upload.get("preview_url")
-            if not isinstance(url, str) or not url:
-                continue
-            file_name = str(upload.get("name") or "file")
-            file_label = f"{activity_title}_提交_{file_name}"
-            output_path = LMSBatchDownloadThread._build_output_path(
-                f"提交_{file_name}", safe_title, dialog.target_dir, dialog.layout_mode
-            )
-            files.append((url, output_path, file_label))
-
-    def _collect_marked_attachments(
-        self, files: list, detail: dict, safe_title: str,
-        dialog: LMSBatchDownloadDialog, activity_title: str,
-        session, util
-    ):
-        """收集批阅附件。"""
-        submission_list = detail.get("submission_list", {})
-        if not isinstance(submission_list, dict):
-            return
-        sub_items = submission_list.get("list")
-        if not isinstance(sub_items, list):
-            return
-        total_subs = len(sub_items)
-        self.success(
-            self.tr("收集批阅附件"),
-            self.tr("「{0}」共 {1} 次提交，正在检查批阅…").format(activity_title, total_subs),
-            duration=2000,
-            parent=self,
-        )
-        for item in sub_items:
-            if not isinstance(item, dict):
-                continue
-            submission_id = item.get("id")
-            if not isinstance(submission_id, int):
-                continue
-            try:
-                marked_data = util.get_submission_marked_attachments(submission_id)
-            except Exception:
-                continue
-            if not isinstance(marked_data, dict):
-                continue
-            rules = marked_data.get("rules")
-            if not isinstance(rules, list):
-                continue
-            for rule in rules:
-                if not isinstance(rule, dict):
-                    continue
-                url = rule.get("url") or rule.get("marked_attachment_url")
-                if not isinstance(url, str) or not url.startswith(("http://", "https://")):
-                    continue
-                origin_name = rule.get("origin_upload_name") or "批阅文件"
-                safe_origin = self.sanitize_filename(str(origin_name))
-                if "." in safe_origin and not safe_origin.endswith("."):
-                    file_name = safe_origin.rsplit(".", 1)[0] + "_批阅." + safe_origin.rsplit(".", 1)[1]
-                else:
-                    file_name = safe_origin + "_批阅"
-                file_label = f"{activity_title}_批阅_{file_name}"
-                output_path = LMSBatchDownloadThread._build_output_path(
-                    f"批阅_{file_name}", safe_title, dialog.target_dir, dialog.layout_mode
-                )
-                files.append((url, output_path, file_label))
-
-    @staticmethod
-    def _collect_replay_videos(
-        files: list, detail: dict, safe_title: str,
-        dialog: LMSBatchDownloadDialog, activity_title: str
-    ):
-        """收集回放视频。"""
-        replay_videos = detail.get("replay_videos", [])
-        if not isinstance(replay_videos, list):
-            return
-        for video in replay_videos:
-            if not isinstance(video, dict):
-                continue
-            url = video.get("download_url") or video.get("play_url")
-            if not isinstance(url, str) or not url:
-                continue
-            label = format_replay_video_label(video.get("label"))
-            size = video.get("size", 0)
-            size_str = common_format_size(size)
-            file_name = f"{label}_{size_str}.mp4"
-            file_label = f"{activity_title}_{label}"
-            output_path = LMSBatchDownloadThread._build_output_path(
-                file_name, safe_title, dialog.target_dir, dialog.layout_mode
-            )
-            files.append((url, output_path, file_label))
-
-    def _start_batch_download(self, files: list, session):
-        """启动批量下载线程并显示进度条。"""
         bar = ProgressInfoBar(
             title=self.tr("批量下载"),
-            content=self.tr("0 / {0} 个文件").format(len(files)),
+            content=self.tr("正在准备…"),
             parent=self,
             position=InfoBarPosition.BOTTOM_RIGHT,
         )
 
-        thread = LMSBatchDownloadThread(self)
-        for url, output_path, file_label in files:
-            thread.add_job(url, output_path, file_label, session)
+        thread = LMSBatchDownloadThread(
+            selected_activities=selected_activities,
+            activity_type=activity_type,
+            account=current_account,
+            target_dir=dialog.target_dir,
+            layout_mode=dialog.layout_mode,
+            download_uploads=dialog.download_uploads,
+            download_submissions=dialog.download_submissions,
+            download_marked=dialog.download_marked,
+            parent=self,
+        )
 
         bar.connectToThread(thread)
         thread.allCompleted.connect(
-            lambda success, fail: self._onBatchDownloadFinished(success, fail, len(files), bar)
+            lambda success, fail: self._onBatchDownloadFinished(success, fail, bar)
         )
+        thread.fileCompleted.connect(
+            lambda label, ok, msg: (
+                InfoBar.error(
+                    self.tr("下载失败"), f"{label}\n{msg}",
+                    duration=3000,
+                    position=InfoBarPosition.BOTTOM_RIGHT,
+                    parent=self.window(),
+                ) if not ok else None
+            )
+        )
+        thread.error.connect(lambda title, msg: self.error(title, msg, parent=self))
 
         self._download_jobs.append((bar, thread))
         thread.finished.connect(lambda: self._cleanup_download_job(bar, thread))
@@ -1302,8 +1117,9 @@ class LMSInterface(ScrollArea):
         bar.show()
         thread.start()
 
-    def _onBatchDownloadFinished(self, success: int, fail: int, total: int, bar: ProgressInfoBar):
+    def _onBatchDownloadFinished(self, success: int, fail: int, bar: ProgressInfoBar):
         """批量下载全部完成回调。"""
+        total = success + fail
         if fail > 0:
             self.success(
                 self.tr("批量下载完成"),

--- a/app/LMSInterface.py
+++ b/app/LMSInterface.py
@@ -8,7 +8,7 @@ from urllib.parse import urlparse, unquote
 
 from PyQt5.QtCore import pyqtSlot, Qt, QUrl, QStandardPaths, QBuffer
 from PyQt5.QtGui import QDesktopServices, QImageReader, QPixmap
-from PyQt5.QtWidgets import QWidget, QVBoxLayout, QFrame, QHBoxLayout, QFileDialog, QSizePolicy
+from PyQt5.QtWidgets import QWidget, QVBoxLayout, QFrame, QHBoxLayout, QFileDialog, QSizePolicy, QDialog
 from qfluentwidgets import ScrollArea, TitleLabel, StrongBodyLabel, InfoBar, InfoBarPosition, BreadcrumbBar, \
     TransparentToolButton, FluentIcon
 
@@ -21,11 +21,13 @@ from .threads.ProcessWidget import ProcessWidget
 from .utils import StyleSheet, accounts, AccountDataManager, cfg
 from .sub_interfaces.lms import PageStatus, LMSStartPage, LMSCoursePage, LMSActivityPage, LMSDetailPage, LMSSubmissionPage, LMSVideoPage
 from .sub_interfaces.lms.image_preview_dialog import LMSImagePreviewDialog
+from .sub_interfaces.lms.batch_download_dialog import LMSBatchDownloadDialog
 from .sub_interfaces.lms.common import format_size as common_format_size, format_replay_video_label, \
     can_preview_as_image, is_mark_attachment_upload
 from auth import getVPNUrl
 from lms import LMSUtil
 from lms.models import ActivityType
+from .threads.LMSBatchDownloadThread import LMSBatchDownloadThread
 
 
 class LMSInterface(ScrollArea):
@@ -164,6 +166,7 @@ class LMSInterface(ScrollArea):
         self.submissionPage.previewRequested.connect(self.show_attachment_preview)
         self.submissionPage.reviewPreviewRequested.connect(self.show_attachment_review_preview)
         self.submissionPage.markedAttachmentsDebugRequested.connect(self.dump_current_submission_marked_attachments)
+        self.activityPage.batchDownloadRequested.connect(self.onBatchDownloadRequested)
 
     def _initNavigationModel(self):
         """初始化页面与路由键的双向映射。"""
@@ -1037,6 +1040,283 @@ class LMSInterface(ScrollArea):
     def _cleanup_download_job(self, bar: ProgressInfoBar, thread: LMSFileDownloadThread):
         """清理已结束或取消的下载任务引用。"""
         self._download_jobs = [one for one in self._download_jobs if one != (bar, thread)]
+
+    @pyqtSlot(list)
+    def onBatchDownloadRequested(self, selected_activities: list[dict]):
+        """处理批量下载请求。
+
+        弹出对话框让用户选择，确认后获取活动详情、收集文件并启动批量下载。
+
+        :param selected_activities: 用户选中的活动字典列表。
+        :return: 无返回值。
+        """
+        if not selected_activities:
+            return
+
+        activity_type = self.activityPage.activity_type_filter
+        total_count = sum(
+            1 for a in self._current_activities
+            if isinstance(a, dict) and str(a.get("type") or "") == activity_type
+        )
+
+        # 弹对话框
+        dialog = LMSBatchDownloadDialog(
+            activity_type=activity_type,
+            selected_activities=selected_activities,
+            course_name=self.selected_course_name,
+            total_count=total_count,
+            parent=self.window(),
+        )
+
+        if dialog.exec() != QDialog.Accepted:
+            return
+
+        # 登录
+        session, error = self.ensure_lms_login()
+        if session is None:
+            self.error(self.tr("未登录"), error or self.tr("请先添加一个账户"), parent=self)
+            return
+
+        util = self._get_lms_util()
+        if util is None:
+            self.error(self.tr("错误"), self.tr("无法获取 LMS 工具实例"), parent=self)
+            return
+
+        # 收集文件
+        files: list[tuple[str, str, str]] = []
+
+        for activity in selected_activities:
+            if not isinstance(activity, dict):
+                continue
+            activity_id = activity.get("id")
+            activity_title = str(activity.get("title") or "-")
+            safe_title = self.sanitize_filename(activity_title)
+            act_type = str(activity.get("type") or "")
+
+            detail = self._get_cached_activity_detail(activity_id, util)
+            if detail is None:
+                self.error(
+                    self.tr("跳过活动"),
+                    self.tr("无法获取「{0}」的详情，跳过").format(activity_title),
+                    parent=self,
+                )
+                continue
+
+            if act_type == ActivityType.HOMEWORK.value:
+                if dialog.download_uploads:
+                    self._collect_uploads(files, detail, safe_title, dialog, activity_title)
+                if dialog.download_submissions:
+                    self._collect_submission_uploads(
+                        files, detail, safe_title, dialog, activity_title, session, util
+                    )
+                if dialog.download_marked:
+                    self._collect_marked_attachments(
+                        files, detail, safe_title, dialog, activity_title, session, util
+                    )
+            elif act_type == ActivityType.MATERIAL.value:
+                self._collect_uploads(files, detail, safe_title, dialog, activity_title)
+            elif act_type == ActivityType.LESSON.value:
+                self._collect_replay_videos(files, detail, safe_title, dialog, activity_title)
+
+        if not files:
+            self.error(self.tr("无可下载文件"), self.tr("没有找到任何可下载的文件"), parent=self)
+            return
+
+        self._start_batch_download(files, session)
+
+    def _get_cached_activity_detail(self, activity_id: int, util) -> dict | None:
+        """获取活动的详细数据（含 uploads）。
+
+        优先使用缓存的活动列表数据（如果已有 uploads），
+        否则请求详情 API。
+        """
+        for one in self._current_activities:
+            if isinstance(one, dict) and one.get("id") == activity_id:
+                uploads = one.get("uploads")
+                if isinstance(uploads, list):
+                    return one
+                break
+
+        try:
+            detail = util.get_activity_detail(activity_id)
+            if isinstance(detail, dict):
+                return detail
+        except Exception:
+            pass
+        return None
+
+    @staticmethod
+    def _collect_uploads(
+        files: list, detail: dict, safe_title: str,
+        dialog: LMSBatchDownloadDialog, activity_title: str
+    ):
+        """收集活动附件。"""
+        uploads = detail.get("uploads", [])
+        if not isinstance(uploads, list):
+            return
+        for upload in uploads:
+            if not isinstance(upload, dict):
+                continue
+            url = upload.get("download_url") or upload.get("preview_url")
+            if not isinstance(url, str) or not url:
+                continue
+            file_name = str(upload.get("name") or "file")
+            file_label = f"{activity_title}_{file_name}"
+            output_path = LMSBatchDownloadThread._build_output_path(
+                file_name, safe_title, dialog.target_dir, dialog.layout_mode
+            )
+            files.append((url, output_path, file_label))
+
+    @staticmethod
+    def _collect_submission_uploads(
+        files: list, detail: dict, safe_title: str,
+        dialog: LMSBatchDownloadDialog, activity_title: str,
+        session, util
+    ):
+        """收集提交附件。"""
+        submission_list = detail.get("submission_list", {})
+        if not isinstance(submission_list, dict):
+            return
+        all_uploads: list[dict] = []
+        sub_uploads = submission_list.get("uploads")
+        if isinstance(sub_uploads, list):
+            all_uploads.extend(u for u in sub_uploads if isinstance(u, dict))
+        sub_items = submission_list.get("list")
+        if isinstance(sub_items, list):
+            for item in sub_items:
+                if not isinstance(item, dict):
+                    continue
+                item_uploads = item.get("uploads")
+                if isinstance(item_uploads, list):
+                    all_uploads.extend(u for u in item_uploads if isinstance(u, dict))
+        for upload in all_uploads:
+            url = upload.get("download_url") or upload.get("preview_url")
+            if not isinstance(url, str) or not url:
+                continue
+            file_name = str(upload.get("name") or "file")
+            file_label = f"{activity_title}_提交_{file_name}"
+            output_path = LMSBatchDownloadThread._build_output_path(
+                f"提交_{file_name}", safe_title, dialog.target_dir, dialog.layout_mode
+            )
+            files.append((url, output_path, file_label))
+
+    def _collect_marked_attachments(
+        self, files: list, detail: dict, safe_title: str,
+        dialog: LMSBatchDownloadDialog, activity_title: str,
+        session, util
+    ):
+        """收集批阅附件。"""
+        submission_list = detail.get("submission_list", {})
+        if not isinstance(submission_list, dict):
+            return
+        sub_items = submission_list.get("list")
+        if not isinstance(sub_items, list):
+            return
+        total_subs = len(sub_items)
+        self.success(
+            self.tr("收集批阅附件"),
+            self.tr("「{0}」共 {1} 次提交，正在检查批阅…").format(activity_title, total_subs),
+            duration=2000,
+            parent=self,
+        )
+        for item in sub_items:
+            if not isinstance(item, dict):
+                continue
+            submission_id = item.get("id")
+            if not isinstance(submission_id, int):
+                continue
+            try:
+                marked_data = util.get_submission_marked_attachments(submission_id)
+            except Exception:
+                continue
+            if not isinstance(marked_data, dict):
+                continue
+            rules = marked_data.get("rules")
+            if not isinstance(rules, list):
+                continue
+            for rule in rules:
+                if not isinstance(rule, dict):
+                    continue
+                url = rule.get("url") or rule.get("marked_attachment_url")
+                if not isinstance(url, str) or not url.startswith(("http://", "https://")):
+                    continue
+                origin_name = rule.get("origin_upload_name") or "批阅文件"
+                safe_origin = self.sanitize_filename(str(origin_name))
+                if "." in safe_origin and not safe_origin.endswith("."):
+                    file_name = safe_origin.rsplit(".", 1)[0] + "_批阅." + safe_origin.rsplit(".", 1)[1]
+                else:
+                    file_name = safe_origin + "_批阅"
+                file_label = f"{activity_title}_批阅_{file_name}"
+                output_path = LMSBatchDownloadThread._build_output_path(
+                    f"批阅_{file_name}", safe_title, dialog.target_dir, dialog.layout_mode
+                )
+                files.append((url, output_path, file_label))
+
+    @staticmethod
+    def _collect_replay_videos(
+        files: list, detail: dict, safe_title: str,
+        dialog: LMSBatchDownloadDialog, activity_title: str
+    ):
+        """收集回放视频。"""
+        replay_videos = detail.get("replay_videos", [])
+        if not isinstance(replay_videos, list):
+            return
+        for video in replay_videos:
+            if not isinstance(video, dict):
+                continue
+            url = video.get("download_url") or video.get("play_url")
+            if not isinstance(url, str) or not url:
+                continue
+            label = format_replay_video_label(video.get("label"))
+            size = video.get("size", 0)
+            size_str = common_format_size(size)
+            file_name = f"{label}_{size_str}.mp4"
+            file_label = f"{activity_title}_{label}"
+            output_path = LMSBatchDownloadThread._build_output_path(
+                file_name, safe_title, dialog.target_dir, dialog.layout_mode
+            )
+            files.append((url, output_path, file_label))
+
+    def _start_batch_download(self, files: list, session):
+        """启动批量下载线程并显示进度条。"""
+        bar = ProgressInfoBar(
+            title=self.tr("批量下载"),
+            content=self.tr("0 / {0} 个文件").format(len(files)),
+            parent=self,
+            position=InfoBarPosition.BOTTOM_RIGHT,
+        )
+
+        thread = LMSBatchDownloadThread(self)
+        for url, output_path, file_label in files:
+            thread.add_job(url, output_path, file_label, session)
+
+        bar.connectToThread(thread)
+        thread.allCompleted.connect(
+            lambda success, fail: self._onBatchDownloadFinished(success, fail, len(files), bar)
+        )
+
+        self._download_jobs.append((bar, thread))
+        thread.finished.connect(lambda: self._cleanup_download_job(bar, thread))
+        thread.canceled.connect(lambda: self._cleanup_download_job(bar, thread))
+
+        bar.show()
+        thread.start()
+
+    def _onBatchDownloadFinished(self, success: int, fail: int, total: int, bar: ProgressInfoBar):
+        """批量下载全部完成回调。"""
+        if fail > 0:
+            self.success(
+                self.tr("批量下载完成"),
+                self.tr("成功 {0} / {1}，失败 {2} 个").format(success, total, fail),
+                duration=5000,
+                parent=self,
+            )
+        else:
+            self.success(
+                self.tr("批量下载完成"),
+                self.tr("成功下载 {0} 个文件").format(success),
+                parent=self,
+            )
 
     @pyqtSlot(dict, list)
     def show_attachment_preview(self, file_info: dict, uploads: list):

--- a/app/SettingInterface.py
+++ b/app/SettingInterface.py
@@ -324,6 +324,16 @@ class SettingInterface(ScrollArea):
         )
         self.lmsGroup.addSettingCard(self.lmsCacheCard)
 
+        self.lmsConcurrencyCard = ComboBoxSettingCard(
+            cfg.lmsBatchDownloadConcurrency,
+            FIF.SPEED_HIGH,
+            self.tr("批量下载并发数"),
+            self.tr("同时下载的文件数量，数字越大下载越快"),
+            texts=[str(i) for i in range(1, 7)],
+            parent=self.lmsGroup,
+        )
+        self.lmsGroup.addSettingCard(self.lmsConcurrencyCard)
+
         # 通知查询组
         self.noticeGroup = SettingCardGroup(self.tr("定时查询"), self.view)
         self.noticeCard = NoticeSearchCard(self, self.view)

--- a/app/cards/lms_activity_card.py
+++ b/app/cards/lms_activity_card.py
@@ -1,13 +1,16 @@
-from PyQt5.QtCore import Qt
+from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtWidgets import QHBoxLayout, QVBoxLayout
-from qfluentwidgets import CardWidget, IconWidget, BodyLabel, CaptionLabel, FluentIcon
+from qfluentwidgets import CardWidget, IconWidget, BodyLabel, CaptionLabel, FluentIcon, CheckBox
 
 from lms.models import ActivityType
-from app.sub_interfaces.lms.common import time_text
+
+
+
 
 
 class LMSActivityCard(CardWidget):
     """LMS 活动通用卡片。"""
+    checkedChanged = pyqtSignal(int, bool)  # activity_id, checked
 
     def __init__(self, activity: dict, parent=None):
         super().__init__(parent)
@@ -16,8 +19,14 @@ class LMSActivityCard(CardWidget):
         self.activity_id = self._activity.get("id")
         self.activity_title = str(self._activity.get("title") or "-")
         self.activity_type = str(self._activity.get("type") or "")
+        self._checked = False
 
         self.setFixedWidth(370)
+
+        self.checkBox = CheckBox(self)
+        self.checkBox.setFixedWidth(24)
+        self.checkBox.setVisible(False)
+        self.checkBox.stateChanged.connect(self._onCheckBoxChanged)
 
         self.iconWidget = IconWidget(self._iconForType(self.activity_type), self)
         self.iconWidget.setFixedSize(30, 30)
@@ -31,7 +40,8 @@ class LMSActivityCard(CardWidget):
 
         self.hBoxLayout = QHBoxLayout(self)
         self.hBoxLayout.setContentsMargins(20, 14, 14, 14)
-        self.hBoxLayout.setSpacing(14)
+        self.hBoxLayout.setSpacing(8)
+        self.hBoxLayout.addWidget(self.checkBox, 0, Qt.AlignVCenter)
         self.hBoxLayout.addWidget(self.iconWidget, 0, Qt.AlignVCenter)
 
         self.vBoxLayout = QVBoxLayout()
@@ -42,6 +52,25 @@ class LMSActivityCard(CardWidget):
         self.vBoxLayout.addStretch(1)
 
         self.hBoxLayout.addLayout(self.vBoxLayout, stretch=1)
+
+    def setSelectionMode(self, enabled: bool):
+        """进入/退出选择模式。"""
+        # 直播间活动不支持下载，不显示勾选框
+        can_select = enabled and self.activity_type != ActivityType.LECTURE_LIVE.value
+        self.checkBox.setVisible(can_select)
+        if not can_select:
+            self.setChecked(False)
+
+    def isChecked(self) -> bool:
+        return self._checked
+
+    def setChecked(self, checked: bool):
+        self.checkBox.setChecked(checked)
+
+    def _onCheckBoxChanged(self, state: int):
+        self._checked = state == Qt.Checked
+        if self.activity_id is not None:
+            self.checkedChanged.emit(self.activity_id, self._checked)
 
     @staticmethod
     def _iconForType(activity_type: str):
@@ -54,6 +83,7 @@ class LMSActivityCard(CardWidget):
         return mapping.get(activity_type, FluentIcon.DOCUMENT)
 
     def _metaText(self) -> str:
+        from app.sub_interfaces.lms.common import time_text
         if self.activity_type == ActivityType.HOMEWORK.value:
             start = time_text(self._activity.get("start_time"))
             end = time_text(self._activity.get("end_time"))

--- a/app/cards/lms_activity_card.py
+++ b/app/cards/lms_activity_card.py
@@ -5,9 +5,6 @@ from qfluentwidgets import CardWidget, IconWidget, BodyLabel, CaptionLabel, Flue
 from lms.models import ActivityType
 
 
-
-
-
 class LMSActivityCard(CardWidget):
     """LMS 活动通用卡片。"""
     checkedChanged = pyqtSignal(int, bool)  # activity_id, checked

--- a/app/sub_interfaces/lms/__init__.py
+++ b/app/sub_interfaces/lms/__init__.py
@@ -5,6 +5,7 @@ from .activity_page import LMSActivityPage
 from .detail_page import LMSDetailPage
 from .submission_page import LMSSubmissionPage
 from .video_page import LMSVideoPage
+from .batch_download_dialog import LMSBatchDownloadDialog
 
 __all__ = [
     "PageStatus",
@@ -14,4 +15,5 @@ __all__ = [
     "LMSDetailPage",
     "LMSSubmissionPage",
     "LMSVideoPage",
+    "LMSBatchDownloadDialog",
 ]

--- a/app/sub_interfaces/lms/activity_page.py
+++ b/app/sub_interfaces/lms/activity_page.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtWidgets import QActionGroup, QFrame, QHBoxLayout, QVBoxLayout, QWidget, QSizePolicy
 from qfluentwidgets import Action, BodyLabel, CheckableMenu, FlowLayout, FluentIcon, MenuIndicatorType, Pivot, \
-    TransparentDropDownPushButton
+    TransparentDropDownPushButton, PushButton, PrimaryPushButton, StrongBodyLabel
 
 from lms.models import ActivityType
 from app.cards.lms_activity_card import LMSActivityCard
@@ -17,6 +17,8 @@ class LMSActivityPage(QFrame):
     activityTypeChanged = pyqtSignal(str)
     # 用户点击重试按钮后，请求主容器重新加载活动。
     retryRequested = pyqtSignal()
+    # 用户请求批量下载，携带选中的活动字典列表。
+    batchDownloadRequested = pyqtSignal(list)
 
     def __init__(self, parent=None):
         """初始化活动页组件与筛选器。"""
@@ -26,10 +28,13 @@ class LMSActivityPage(QFrame):
         self._activities: list[dict] = []
         self._filtered_activities: list[dict] = []
         self._activity_cards: list[QWidget] = []
+        self._selection_mode = False
+        self._selected_activity_ids: set[int] = set()
 
         layout = QVBoxLayout(self)
         layout.setAlignment(Qt.AlignTop)
 
+        # ---------- 顶部栏：Pivot + 选择按钮 ----------
         self.topBar = QFrame(self)
         self.topBarLayout = QHBoxLayout(self.topBar)
         self.topBarLayout.setContentsMargins(0, 0, 0, 0)
@@ -61,8 +66,44 @@ class LMSActivityPage(QFrame):
         self.sortMenu.addActions([self.lessonTimeAscAction, self.lessonTimeDescAction])
         self.sortButton.setMenu(self.sortMenu)
 
-        self.topBarLayout.addWidget(self.activityTypePivot, stretch=1)
+        # 固定宽度的文本选择/取消选择按钮（同一位置切换）
+        self.selectButton = PushButton(self.tr("选择"), self.topBar)
+        self.selectButton.setFixedWidth(80)
+        self.selectButton.clicked.connect(self._enterSelectionMode)
 
+        self.cancelSelectButton = PushButton(self.tr("取消选择"), self.topBar)
+        self.cancelSelectButton.setFixedWidth(80)
+        self.cancelSelectButton.setVisible(False)
+        self.cancelSelectButton.clicked.connect(self._exitSelectionMode)
+
+        self.topBarLayout.addWidget(self.activityTypePivot, stretch=1)
+        self.topBarLayout.addWidget(self.selectButton)
+        self.topBarLayout.addWidget(self.cancelSelectButton)
+
+        # ---------- 选择模式控制栏 ----------
+        self.selectionBar = QFrame(self)
+        self.selectionBar.setVisible(False)
+        self.selectionBarLayout = QHBoxLayout(self.selectionBar)
+        self.selectionBarLayout.setContentsMargins(0, 6, 0, 6)
+        self.selectionBarLayout.setSpacing(12)
+
+        self.selectAllCheck = PushButton(self.tr("全选"), self.selectionBar)
+        self.selectAllCheck.setFixedWidth(80)
+        self.selectAllCheck.clicked.connect(self._onSelectAllClicked)
+
+        self.batchDownloadButton = PrimaryPushButton(self.tr("批量下载"), self.selectionBar)
+        self.batchDownloadButton.setEnabled(False)
+        self.batchDownloadButton.clicked.connect(self._onBatchDownloadClicked)
+
+        self.selectionInfoLabel = StrongBodyLabel("", self.selectionBar)
+        self.selectionInfoLabel.setVisible(False)
+
+        self.selectionBarLayout.addWidget(self.selectAllCheck)
+        self.selectionBarLayout.addWidget(self.batchDownloadButton)
+        self.selectionBarLayout.addStretch(1)
+        self.selectionBarLayout.addWidget(self.selectionInfoLabel)
+
+        # ---------- 卡片容器 ----------
         self.cardHost = QWidget(self)
         self.flowLayout = FlowLayout(self.cardHost, needAni=False)
         self.flowLayout.setContentsMargins(0, 0, 0, 0)
@@ -76,7 +117,9 @@ class LMSActivityPage(QFrame):
         self.failFrame.setVisible(False)
         retry_button.clicked.connect(self.retryRequested.emit)
 
+        # ---------- 组装布局 ----------
         layout.addWidget(self.topBar)
+        layout.addWidget(self.selectionBar)
         layout.addWidget(self.sortButton, alignment=Qt.AlignHCenter)
         layout.addWidget(self.cardHost)
         layout.addWidget(self.loadingFrame)
@@ -152,6 +195,13 @@ class LMSActivityPage(QFrame):
         """
         return [one for one in self._activities if isinstance(one, dict)]
 
+    def getSelectedActivities(self) -> list[dict]:
+        """获取当前选中的活动字典列表（在过滤后的结果中查找）。"""
+        return [
+            one for one in self._filtered_activities
+            if isinstance(one, dict) and one.get("id") in self._selected_activity_ids
+        ]
+
     def filterActivities(self, key: str):
         """按活动类型过滤并重绘表格。
 
@@ -178,6 +228,7 @@ class LMSActivityPage(QFrame):
 
         :return: 无返回值。
         """
+        self._exitSelectionMode()
         self._activities = []
         self._filtered_activities = []
         self._clearActivityCards()
@@ -202,8 +253,113 @@ class LMSActivityPage(QFrame):
         """
         self.cardHost.setEnabled(enabled)
 
+    def _enterSelectionMode(self):
+        """进入选择模式。"""
+        self._selection_mode = True
+        self.selectButton.setVisible(False)
+        self.cancelSelectButton.setVisible(True)
+        self.selectionBar.setVisible(True)
+        self.sortButton.setVisible(False)
+        # 通知已有卡片显示勾选框
+        for card in self._activity_cards:
+            if isinstance(card, LMSActivityCard):
+                card.setSelectionMode(True)
+        self._updateSelectionUI()
+
+    def _exitSelectionMode(self):
+        """退出选择模式，清空勾选。"""
+        self._selection_mode = False
+        self._selected_activity_ids.clear()
+        self.selectButton.setVisible(True)
+        self.cancelSelectButton.setVisible(False)
+        self.selectionBar.setVisible(False)
+        self.batchDownloadButton.setEnabled(False)
+        self.selectionInfoLabel.setVisible(False)
+        self._updateSortButtonVisibility(self.activity_type_filter)
+        # 更新所有卡片退出选择模式
+        for card in self._activity_cards:
+            if isinstance(card, LMSActivityCard):
+                card.setSelectionMode(False)
+
+    def _updateSelectionUI(self):
+        """根据选择状态刷新按钮和信息栏。"""
+        count = len(self._selected_activity_ids)
+        total = len([c for c in self._activity_cards if isinstance(c, LMSActivityCard) and c.activity_id is not None])
+
+        self.batchDownloadButton.setEnabled(count > 0)
+        if count > 0:
+            self.selectionInfoLabel.setText(self.tr("已选择 {0} / {1} 个活动").format(count, total))
+            self.selectionInfoLabel.setVisible(True)
+        else:
+            self.selectionInfoLabel.setText(self.tr("共 {0} 个活动").format(total))
+            self.selectionInfoLabel.setVisible(True)
+
+        # 更新「全选」按钮文本
+        all_selected = count == total if total > 0 else False
+        self.selectAllCheck.setText(self.tr("取消全选") if all_selected else self.tr("全选"))
+
+    def _onSelectAllClicked(self):
+        """处理全选/取消全选。"""
+        total = len([c for c in self._activity_cards if isinstance(c, LMSActivityCard) and c.activity_id is not None])
+        all_selected = len(self._selected_activity_ids) == total if total > 0 else False
+
+        if all_selected:
+            # 取消全选
+            self._selected_activity_ids.clear()
+            for card in self._activity_cards:
+                if isinstance(card, LMSActivityCard):
+                    card.setChecked(False)
+        else:
+            # 全选
+            self._selected_activity_ids = {
+                card.activity_id for card in self._activity_cards
+                if isinstance(card, LMSActivityCard) and card.activity_id is not None
+            }
+            for card in self._activity_cards:
+                if isinstance(card, LMSActivityCard):
+                    card.setChecked(True)
+
+        self._updateSelectionUI()
+
+    def _onCardCheckedChanged(self, activity_id: int, checked: bool):
+        """处理卡片勾选状态变化。"""
+        if checked:
+            self._selected_activity_ids.add(activity_id)
+        else:
+            self._selected_activity_ids.discard(activity_id)
+        self._updateSelectionUI()
+
+    def _onActivityClicked(self, activity: dict):
+        """处理活动点击事件。
+        选择模式下：切换勾选。
+        正常模式下：进入详情页。
+        """
+        if self._selection_mode:
+            # 在选择模式下，找到对应卡片并切换勾选
+            activity_id = activity.get("id") if isinstance(activity, dict) else None
+            for card in self._activity_cards:
+                if isinstance(card, LMSActivityCard) and card.activity_id == activity_id:
+                    card.setChecked(not card.isChecked())
+                    return
+            return
+
+        if not isinstance(activity, dict):
+            return
+        activity_id = activity.get("id")
+        if not isinstance(activity_id, int):
+            return
+        self.activitySelected.emit(activity_id, str(activity.get("title") or "-"))
+
+    def _onBatchDownloadClicked(self):
+        """处理批量下载按钮点击。"""
+        selected = self.getSelectedActivities()
+        if not selected:
+            return
+        self.batchDownloadRequested.emit(selected)
+
     def _onActivityTypeChanged(self, key: str):
-        """处理 Pivot 类型切换并发出类型变化信号。"""
+        """处理 Pivot 类型切换：退出选择模式并发出类型变化信号。"""
+        self._exitSelectionMode()
         self.activity_type_filter = key
         self.filterActivities(key)
         self.activityTypeChanged.emit(key)
@@ -214,7 +370,10 @@ class LMSActivityPage(QFrame):
 
     def _updateSortButtonVisibility(self, key: str):
         """仅在课程回放分类下显示排序按钮。"""
-        self.sortButton.setVisible(key == ActivityType.LESSON.value)
+        if self._selection_mode:
+            self.sortButton.setVisible(False)
+        else:
+            self.sortButton.setVisible(key == ActivityType.LESSON.value)
 
     def _sortActivities(self, activities: list[dict], key: str) -> list[dict]:
         """按当前筛选类型返回排序后的活动列表。"""
@@ -259,23 +418,22 @@ class LMSActivityPage(QFrame):
         # 在没有活动时，显示一个简单的提示
         if not self._filtered_activities:
             label = BodyLabel(self.tr("当前分类下暂无内容"), self.cardHost)
-            # 将这个 label 加到 activity_card 中，这样就可以跟随活动切换而消失了
             self.flowLayout.addWidget(label)
             self._activity_cards.append(label)
+            return
 
         for activity in self._filtered_activities:
             card = LMSActivityCard(activity, self.cardHost)
+            card.checkedChanged.connect(self._onCardCheckedChanged)
             card.clicked.connect(lambda _=False, one=activity: self._onActivityClicked(one))
+
+            # 如果是选择模式，保持勾选状态
+            if self._selection_mode:
+                card.setSelectionMode(True)
+                if isinstance(activity, dict) and activity.get("id") in self._selected_activity_ids:
+                    card.setChecked(True)
+
             self.flowLayout.addWidget(card)
             self._activity_cards.append(card)
 
         self.cardHost.adjustSize()
-
-    def _onActivityClicked(self, activity: dict):
-        """处理活动点击事件并发出活动选择信号。"""
-        if not isinstance(activity, dict):
-            return
-        activity_id = activity.get("id")
-        if not isinstance(activity_id, int):
-            return
-        self.activitySelected.emit(activity_id, str(activity.get("title") or "-"))

--- a/app/sub_interfaces/lms/batch_download_dialog.py
+++ b/app/sub_interfaces/lms/batch_download_dialog.py
@@ -1,0 +1,162 @@
+from typing import Optional
+
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import QVBoxLayout, QHBoxLayout, QWidget, QFileDialog, QButtonGroup
+from qfluentwidgets import MessageBoxBase, BodyLabel, StrongBodyLabel, RadioButton, \
+    CheckBox, PushButton, PrimaryPushButton, FluentIcon, LineEdit
+
+from lms.models import ActivityType
+
+
+class LMSBatchDownloadDialog(MessageBoxBase):
+    """LMS 批量下载确认对话框。"""
+
+    def __init__(
+        self,
+        activity_type: str,
+        selected_activities: list[dict],
+        course_name: str,
+        total_count: int = 0,
+        parent=None,
+    ):
+        """初始化批量下载确认对话框。
+
+        :param activity_type: 当前活动类型（homework/material/lesson/lecture_live）。
+        :param selected_activities: 用户选中的活动字典列表。
+        :param course_name: 课程名称。
+        :param total_count: 当前类型下的活动总数。
+        :param parent: 父级控件。
+        """
+        super().__init__(parent)
+
+        self.activity_type = activity_type
+        self.selected_activities = [dict(a) for a in selected_activities if isinstance(a, dict)]
+        self.course_name = course_name
+
+        # 用户选择的结果
+        self.layout_mode = "hierarchical"  # "flat" 或 "hierarchical"
+        self.target_dir: Optional[str] = None
+        self.download_uploads = True
+        self.download_submissions = True
+        self.download_marked = False
+
+        self.setupUI(total_count)
+        self._connectSignals()
+
+    def setupUI(self, total_count: int):
+        """构建对话框内容。"""
+        self.contentWidget = QWidget(self)
+        self.content_layout = QVBoxLayout(self.contentWidget)
+        self.content_layout.setAlignment(Qt.AlignTop)
+
+        # ---- 汇总信息 ----
+        self.summaryLabel = BodyLabel(
+            self.tr("课程：{0}").format(self.course_name),
+            self.contentWidget,
+        )
+
+        activity_count = len(self.selected_activities)
+        self.countLabel = BodyLabel(
+            self.tr("选中活动 {0} 个，共 {1} 个").format(activity_count, total_count),
+            self.contentWidget,
+        )
+
+        # ---- 下载位置 ----
+        self.locationGroup = QButtonGroup(self.contentWidget)
+        self.flatRadio = RadioButton(self.tr("统一存放"), self.contentWidget)
+        self.hierarchicalRadio = RadioButton(self.tr("按活动存放"), self.contentWidget)
+        self.hierarchicalRadio.setChecked(True)
+        self.locationGroup.addButton(self.flatRadio)
+        self.locationGroup.addButton(self.hierarchicalRadio)
+
+        # ---- 目标目录 ----
+        self.dirLayout = QHBoxLayout()
+        self.dirEdit = LineEdit(self.contentWidget)
+        self.dirEdit.setPlaceholderText(self.tr("选择目标目录..."))
+        self.dirEdit.setMinimumWidth(280)
+        self.dirEdit.setReadOnly(True)
+        self.dirButton = PushButton(FluentIcon.FOLDER, self.tr("浏览..."), self.contentWidget)
+        self.dirLayout.addWidget(self.dirEdit, stretch=1)
+        self.dirLayout.addWidget(self.dirButton)
+
+        # ---- 下载内容选项（仅对作业生效） ----
+        is_homework = self.activity_type == ActivityType.HOMEWORK.value
+        self.optionLabel = StrongBodyLabel(self.tr("下载内容"), self.contentWidget)
+        self.uploadCheck = CheckBox(self.tr("作业附件"), self.contentWidget)
+        self.submissionCheck = CheckBox(self.tr("提交附件"), self.contentWidget)
+        self.markedCheck = CheckBox(self.tr("批阅附件"), self.contentWidget)
+        self.uploadCheck.setChecked(True)
+        self.submissionCheck.setChecked(True)
+        self.optionLabel.setVisible(is_homework)
+        self.uploadCheck.setVisible(is_homework)
+        self.submissionCheck.setVisible(is_homework)
+        self.markedCheck.setVisible(is_homework)
+
+        # ---- 组装 ----
+        self.content_layout.addWidget(self.summaryLabel)
+        self.content_layout.addWidget(self.countLabel)
+
+        self.content_layout.addSpacing(12)
+        self.content_layout.addWidget(StrongBodyLabel(self.tr("下载位置"), self.contentWidget))
+        self.content_layout.addWidget(self.flatRadio)
+        self.content_layout.addWidget(self.hierarchicalRadio)
+
+        self.content_layout.addSpacing(8)
+        self.content_layout.addLayout(self.dirLayout)
+
+        if is_homework:
+            self.content_layout.addSpacing(12)
+            self.content_layout.addWidget(self.optionLabel)
+            self.content_layout.addWidget(self.uploadCheck)
+            self.content_layout.addWidget(self.submissionCheck)
+            self.content_layout.addWidget(self.markedCheck)
+
+        self.viewLayout.addWidget(self.contentWidget)
+        self.viewLayout.setSpacing(0)
+        self.viewLayout.setContentsMargins(12, 12, 12, 12)
+        self.viewLayout.setSizeConstraint(QVBoxLayout.SetFixedSize)
+
+        self.yesButton.setText(self.tr("开始下载"))
+        self.cancelButton.setText(self.tr("取消"))
+        self.buttonGroup.setVisible(True)
+
+    def _connectSignals(self):
+        """连接信号。"""
+        self.flatRadio.toggled.connect(
+            lambda checked: self._onLocationChanged("flat" if checked else self.layout_mode)
+        )
+        self.hierarchicalRadio.toggled.connect(
+            lambda checked: self._onLocationChanged("hierarchical" if checked else self.layout_mode)
+        )
+        self.dirButton.clicked.connect(self._onBrowseDir)
+        self.uploadCheck.stateChanged.connect(self._onCheckChanged)
+        self.submissionCheck.stateChanged.connect(self._onCheckChanged)
+        self.markedCheck.stateChanged.connect(self._onCheckChanged)
+        self.yesButton.clicked.connect(self._onConfirm)
+
+    def _onLocationChanged(self, mode: str):
+        self.layout_mode = mode
+
+    def _onBrowseDir(self):
+        """打开目录选择对话框。"""
+        directory = QFileDialog.getExistingDirectory(
+            self, self.tr("选择下载目录"), self.dirEdit.text() or ""
+        )
+        if directory:
+            self.target_dir = directory
+            self.dirEdit.setText(directory)
+            self.dirEdit.setError(False)
+
+    def _onCheckChanged(self):
+        """更新下载选项状态。"""
+        self.download_uploads = self.uploadCheck.isChecked()
+        self.download_submissions = self.submissionCheck.isChecked()
+        self.download_marked = self.markedCheck.isChecked()
+
+    def _onConfirm(self):
+        """确认下载前检查参数完整性。"""
+        if not self.target_dir:
+            self.dirEdit.setError(True)
+            self.dirEdit.setFocus()
+            return
+        self.accept()

--- a/app/sub_interfaces/lms/batch_download_dialog.py
+++ b/app/sub_interfaces/lms/batch_download_dialog.py
@@ -132,7 +132,14 @@ class LMSBatchDownloadDialog(MessageBoxBase):
         self.uploadCheck.stateChanged.connect(self._onCheckChanged)
         self.submissionCheck.stateChanged.connect(self._onCheckChanged)
         self.markedCheck.stateChanged.connect(self._onCheckChanged)
-        self.yesButton.clicked.connect(self._onConfirm)
+
+    def validate(self) -> bool:
+        """确认前校验：必须选择目标目录。"""
+        if not self.target_dir:
+            self.dirEdit.setError(True)
+            self.dirEdit.setFocus()
+            return False
+        return True
 
     def _onLocationChanged(self, mode: str):
         self.layout_mode = mode
@@ -152,11 +159,3 @@ class LMSBatchDownloadDialog(MessageBoxBase):
         self.download_uploads = self.uploadCheck.isChecked()
         self.download_submissions = self.submissionCheck.isChecked()
         self.download_marked = self.markedCheck.isChecked()
-
-    def _onConfirm(self):
-        """确认下载前检查参数完整性。"""
-        if not self.target_dir:
-            self.dirEdit.setError(True)
-            self.dirEdit.setFocus()
-            return
-        self.accept()

--- a/app/threads/LMSBatchDownloadThread.py
+++ b/app/threads/LMSBatchDownloadThread.py
@@ -1,0 +1,199 @@
+import os
+import re
+import threading
+from collections import deque
+
+from PyQt5.QtCore import pyqtSignal, QThread
+
+from ..components.ProgressInfoBar import ProgressBarThread
+
+
+class _DownloadJob:
+    """单个下载任务的描述。"""
+
+    def __init__(self, url: str, output_path: str, file_label: str, session):
+        self.url = url
+        self.output_path = output_path
+        self.file_label = file_label
+        self.session = session
+
+
+class LMSBatchDownloadThread(ProgressBarThread):
+    """批量下载协调线程，管理并发下载。"""
+
+    @staticmethod
+    def _sanitize_filename(name: str) -> str:
+        """清理文件名中的非法字符。"""
+        cleaned = re.sub(r'[\\/:*?"<>|]+', "_", name)
+        cleaned = cleaned.strip().strip(".")
+        return cleaned or "file"
+
+    @staticmethod
+    def _build_output_path(file_name: str, safe_activity_title: str, target_dir: str, layout_mode: str) -> str:
+        """根据布局模式构建输出路径。
+
+        :param file_name: 文件名。
+        :param safe_activity_title: 安全的（已清理特殊字符）活动标题。
+        :param target_dir: 用户选择的目标目录。
+        :param layout_mode: "flat" 统一存放，"hierarchical" 按活动存放。
+        :return: 完整的输出文件路径。
+        """
+        safe_name = LMSBatchDownloadThread._sanitize_filename(file_name)
+        if layout_mode == "hierarchical":
+            sub_dir = os.path.join(target_dir, safe_activity_title)
+            os.makedirs(sub_dir, exist_ok=True)
+            return os.path.join(sub_dir, safe_name)
+        return os.path.join(target_dir, safe_name)
+    # 每个文件开始下载时发出 (file_label)
+    fileStarted = pyqtSignal(str)
+    # 每个文件完成时发出 (file_label, success, error_msg)
+    fileCompleted = pyqtSignal(str, bool, str)
+    # 全部完成时发出 (success_count, fail_count)
+    allCompleted = pyqtSignal(int, int)
+
+    MAX_CONCURRENT = 4  # 最大并发数
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._jobs: deque[_DownloadJob] = deque()
+        self._active_workers: list[_WorkerThread] = []
+        self._lock = threading.Lock()
+        self._success_count = 0
+        self._fail_count = 0
+        self._total_jobs = 0
+        self._completed_jobs = 0
+    def add_job(self, url: str, output_path: str, file_label: str, session):
+        """添加一个下载任务到队列。"""
+        self._jobs.append(_DownloadJob(url, output_path, file_label, session))
+
+    def run(self):
+        self._total_jobs = len(self._jobs)
+        if self._total_jobs == 0:
+            self.allCompleted.emit(0, 0)
+            self.hasFinished.emit()
+            return
+
+        self._success_count = 0
+        self._fail_count = 0
+        self._completed_jobs = 0
+
+        self.titleChanged.emit(self.tr("批量下载"))
+        self.messageChanged.emit(self.tr("0 / {0} 已完成").format(self._total_jobs))
+        self.maximumChanged.emit(self._total_jobs)
+        self.progressChanged.emit(0)
+
+        while self._jobs and self.can_run:
+            with self._lock:
+                while len(self._active_workers) < self.MAX_CONCURRENT and self._jobs and self.can_run:
+                    job = self._jobs.popleft()
+                    worker = _WorkerThread(job, self)
+                    worker.finished.connect(self._onWorkerFinished)
+                    self._active_workers.append(worker)
+                    worker.start()
+                    self.fileStarted.emit(job.file_label)
+
+            # 短暂休眠让出 CPU，等 finished 信号回调清理
+            self.msleep(100)
+
+        # 等待所有剩余线程结束
+        with self._lock:
+            remaining = list(self._active_workers)
+        for worker in remaining:
+            worker.wait()
+        with self._lock:
+            self._active_workers.clear()
+
+        if not self.can_run:
+            self.canceled.emit()
+            return
+
+        self.progressChanged.emit(self._total_jobs)
+        self.messageChanged.emit(
+            self.tr("{0} / {1} 已完成").format(self._total_jobs, self._total_jobs)
+        )
+        self.allCompleted.emit(self._success_count, self._fail_count)
+        self.hasFinished.emit()
+
+    def _onWorkerFinished(self):
+        """单个工作线程完成回调。"""
+        worker: _WorkerThread = self.sender()
+        if worker is None:
+            return
+
+        with self._lock:
+            self._completed_jobs += 1
+            if worker.success:
+                self._success_count += 1
+            else:
+                self._fail_count += 1
+            completed = self._completed_jobs
+            if worker in self._active_workers:
+                self._active_workers.remove(worker)
+
+        self.progressChanged.emit(completed)
+        self.messageChanged.emit(
+            self.tr("{0} / {1} 已完成").format(completed, self._total_jobs)
+        )
+        self.fileCompleted.emit(worker.job.file_label, worker.success, worker.error_msg)
+
+    def onStopSignal(self):
+        """停止所有下载。"""
+        super().onStopSignal()
+        with self._lock:
+            workers = list(self._active_workers)
+        for worker in workers:
+            worker.stop()
+
+
+class _WorkerThread(QThread):
+    """单个文件下载工作线程。"""
+
+    def __init__(self, job: _DownloadJob, parent=None):
+        super().__init__(parent)
+        self.job = job
+        self.success = False
+        self.error_msg = ""
+        self._can_run = True
+
+    def stop(self):
+        self._can_run = False
+
+    def run(self):
+        response = None
+        try:
+            response = self.job.session.get(self.job.url, stream=True, timeout=60)
+            response.raise_for_status()
+
+            os.makedirs(os.path.dirname(self.job.output_path), exist_ok=True)
+
+            with open(self.job.output_path, "wb") as f:
+                for chunk in response.iter_content(chunk_size=8192):
+                    if not self._can_run:
+                        self._cleanup()
+                        self.success = False
+                        self.error_msg = self.tr("已取消")
+                        return
+                    if not chunk:
+                        continue
+                    f.write(chunk)
+
+            self.success = True
+        except Exception as e:
+            import logging
+            logging.getLogger("default").exception(
+                "批量下载失败: %s -> %s", self.job.url, self.job.output_path
+            )
+            self._cleanup()
+            self.success = False
+            self.error_msg = str(e)
+        finally:
+            if response is not None:
+                response.close()
+
+    def _cleanup(self):
+        """删除不完整的文件。"""
+        if self.job.output_path and os.path.exists(self.job.output_path):
+            try:
+                os.remove(self.job.output_path)
+            except OSError:
+                pass

--- a/app/threads/LMSBatchDownloadThread.py
+++ b/app/threads/LMSBatchDownloadThread.py
@@ -1,3 +1,5 @@
+import json
+import logging
 import os
 import re
 import threading
@@ -6,12 +8,18 @@ from collections import deque
 from PyQt5.QtCore import pyqtSignal, QThread
 
 from ..components.ProgressInfoBar import ProgressBarThread
-from ..utils import cfg
+from ..sub_interfaces.lms.common import format_size as common_format_size, format_replay_video_label
+from ..utils import cfg, accounts
+from ..sessions.lms_session import LMSSession
+from lms import LMSUtil
+from lms.models import ActivityType
+
+
+logger = logging.getLogger("default")
 
 
 class _DownloadJob:
     """单个下载任务的描述。"""
-
     def __init__(self, url: str, output_path: str, file_label: str, session):
         self.url = url
         self.output_path = output_path
@@ -20,44 +28,32 @@ class _DownloadJob:
 
 
 class LMSBatchDownloadThread(ProgressBarThread):
-    """批量下载协调线程，管理并发下载。"""
+    """批量下载协调线程：先登录 → 收集文件 → 并发下载。"""
 
-    @staticmethod
-    def _sanitize_filename(name: str) -> str:
-        """清理文件名中的非法字符。"""
-        cleaned = re.sub(r'[\\/:*?"<>|]+', "_", name)
-        cleaned = cleaned.strip().strip(".")
-        return cleaned or "file"
-
-    @staticmethod
-    def _build_output_path(file_name: str, safe_activity_title: str, target_dir: str, layout_mode: str) -> str:
-        """根据布局模式构建输出路径。
-
-        :param file_name: 文件名。
-        :param safe_activity_title: 安全的（已清理特殊字符）活动标题。
-        :param target_dir: 用户选择的目标目录。
-        :param layout_mode: "flat" 统一存放，"hierarchical" 按活动存放。
-        :return: 完整的输出文件路径。
-        """
-        safe_name = LMSBatchDownloadThread._sanitize_filename(file_name)
-        if layout_mode == "hierarchical":
-            sub_dir = os.path.join(target_dir, safe_activity_title)
-            os.makedirs(sub_dir, exist_ok=True)
-            return os.path.join(sub_dir, safe_name)
-        return os.path.join(target_dir, safe_name)
-    # 每个文件开始下载时发出 (file_label)
     fileStarted = pyqtSignal(str)
-    # 每个文件完成时发出 (file_label, success, error_msg)
     fileCompleted = pyqtSignal(str, bool, str)
-    # 全部完成时发出 (success_count, fail_count)
     allCompleted = pyqtSignal(int, int)
 
     @staticmethod
     def max_concurrent() -> int:
-        return max(1, min(10, cfg.lmsBatchDownloadConcurrency.value))
+        return max(1, min(6, cfg.lmsBatchDownloadConcurrency.value))
 
-    def __init__(self, parent=None):
+    def __init__(self, selected_activities, activity_type, account,
+                 target_dir, layout_mode,
+                 download_uploads=True, download_submissions=True, download_marked=False,
+                 parent=None):
         super().__init__(parent)
+        self._selected_activities = [dict(a) for a in selected_activities if isinstance(a, dict)]
+        self._activity_type = activity_type
+        self._account = account
+        self._target_dir = target_dir
+        self._layout_mode = layout_mode
+        self._download_uploads = download_uploads
+        self._download_submissions = download_submissions
+        self._download_marked = download_marked
+
+        self._session = None
+        self._util = None
         self._jobs: deque[_DownloadJob] = deque()
         self._active_workers: list[_WorkerThread] = []
         self._lock = threading.Lock()
@@ -65,44 +61,220 @@ class LMSBatchDownloadThread(ProgressBarThread):
         self._fail_count = 0
         self._total_jobs = 0
         self._completed_jobs = 0
-    def add_job(self, url: str, output_path: str, file_label: str, session):
-        """添加一个下载任务到队列。"""
-        self._jobs.append(_DownloadJob(url, output_path, file_label, session))
+
+    def _ensure_login(self) -> bool:
+        """后台线程内登录，失败时 emit error 并返回 False。"""
+        self.titleChanged.emit(self.tr("批量下载"))
+        self.messageChanged.emit(self.tr("正在登录思源学堂…"))
+
+        if self._account is None:
+            self.error.emit(self.tr("未登录"), self.tr("请先添加一个账户"))
+            return False
+
+        try:
+            session = self._account.session_manager.get_session("lms")
+            session.ensure_login(
+                self._account.username,
+                self._account.password,
+                account=self._account,
+                mfa_provider=self._account.session_manager.mfa_provider,
+                allow_qrcode_login=False,
+            )
+        except Exception as e:
+            self.error.emit(self.tr("登录失败"), str(e))
+            return False
+
+        self._session = session
+        self._util = LMSUtil(session)
+        return True
 
     def run(self):
-        self._total_jobs = len(self._jobs)
-        if self._total_jobs == 0:
+        """Phase 0: 登录 → Phase 1: 收集 → Phase 2: 下载"""
+        if not self._ensure_login():
+            self.canceled.emit()
+            return
+
+        # Phase 1: 收集
+        files = self._collect_all()
+        if not self.can_run:
+            self.canceled.emit()
+            return
+        if not files:
+            self.messageChanged.emit(self.tr("没有找到可下载的文件"))
             self.allCompleted.emit(0, 0)
             self.hasFinished.emit()
             return
 
-        self._success_count = 0
-        self._fail_count = 0
-        self._completed_jobs = 0
+        # Phase 2: 下载
+        self._download_all(files)
 
-        self.titleChanged.emit(self.tr("批量下载"))
+    # ──────────── Phase 1: 收集 ────────────
+
+    def _collect_all(self) -> list:
+        total = len(self._selected_activities)
+        files: list = []
+
+        for idx, activity in enumerate(self._selected_activities, start=1):
+            if not self.can_run:
+                return files
+
+            activity_id = activity.get("id")
+            if not isinstance(activity_id, int):
+                continue
+            activity_title = str(activity.get("title") or "-")
+            safe_title = self._sanitize_filename(activity_title)
+            act_type = str(activity.get("type") or "")
+
+            self.messageChanged.emit(
+                self.tr("正在获取活动详情 ({0}/{1})：{2}").format(idx, total, activity_title)
+            )
+            self.progressChanged.emit(int(idx * 50 / total))
+
+            try:
+                detail = self._util.get_activity_detail(activity_id)
+            except Exception as e:
+                logger.exception("获取活动详情失败 activity_id=%s", activity_id)
+                self.messageChanged.emit(self.tr("跳过「{0}」：{1}").format(activity_title, str(e)))
+                continue
+            if not isinstance(detail, dict):
+                continue
+
+            if act_type == ActivityType.HOMEWORK.value:
+                if self._download_uploads:
+                    self._collect_uploads(files, detail, safe_title, activity_title)
+                if self._download_submissions:
+                    self._collect_submission_uploads(files, detail, safe_title, activity_title)
+                if self._download_marked:
+                    self._collect_marked_attachments(files, detail, safe_title, activity_title, self._util)
+            elif act_type == ActivityType.MATERIAL.value:
+                self._collect_uploads(files, detail, safe_title, activity_title)
+            elif act_type == ActivityType.LESSON.value:
+                self._collect_replay_videos(files, detail, safe_title, activity_title)
+
+        return files
+
+    @staticmethod
+    def _sanitize_filename(name: str) -> str:
+        cleaned = re.sub(r'[\\/:*?"<>|]+', "_", name)
+        cleaned = cleaned.strip().strip(".")
+        return cleaned or "file"
+
+    def _output_path(self, file_name: str, safe_activity_title: str) -> str:
+        safe = self._sanitize_filename(file_name)
+        if self._layout_mode == "hierarchical":
+            sub = os.path.join(self._target_dir, safe_activity_title)
+            os.makedirs(sub, exist_ok=True)
+            return os.path.join(sub, safe)
+        return os.path.join(self._target_dir, safe)
+
+    @staticmethod
+    def _collect_uploads(files, detail, safe_title, activity_title):
+        for upload in (detail.get("uploads") or []):
+            if not isinstance(upload, dict):
+                continue
+            url = upload.get("download_url") or upload.get("preview_url")
+            if not isinstance(url, str) or not url:
+                continue
+            name = str(upload.get("name") or "file")
+            files.append((url, name, f"{activity_title}_{name}", safe_title))
+
+    @staticmethod
+    def _collect_submission_uploads(files, detail, safe_title, activity_title):
+        sl = detail.get("submission_list")
+        if not isinstance(sl, dict):
+            return
+        all_u: list[dict] = []
+        up = sl.get("uploads")
+        if isinstance(up, list):
+            all_u.extend(u for u in up if isinstance(u, dict))
+        items = sl.get("list")
+        if isinstance(items, list):
+            for item in items:
+                if not isinstance(item, dict):
+                    continue
+                iu = item.get("uploads")
+                if isinstance(iu, list):
+                    all_u.extend(u for u in iu if isinstance(u, dict))
+        for u in all_u:
+            url = u.get("download_url") or u.get("preview_url")
+            if not isinstance(url, str) or not url:
+                continue
+            name = str(u.get("name") or "file")
+            files.append((url, f"提交_{name}", f"{activity_title}_提交_{name}", safe_title))
+
+    @staticmethod
+    def _collect_marked_attachments(files, detail, safe_title, activity_title, util):
+        sl = detail.get("submission_list")
+        if not isinstance(sl, dict):
+            return
+        items = sl.get("list")
+        if not isinstance(items, list):
+            return
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            sid = item.get("id")
+            if not isinstance(sid, int):
+                continue
+            try:
+                md = util.get_submission_marked_attachments(sid)
+            except Exception:
+                continue
+            if not isinstance(md, dict):
+                continue
+            for rule in (md.get("rules") or []):
+                if not isinstance(rule, dict):
+                    continue
+                url = rule.get("url") or rule.get("marked_attachment_url")
+                if not isinstance(url, str) or not url.startswith(("http://", "https://")):
+                    continue
+                on = rule.get("origin_upload_name") or "批阅文件"
+                so = LMSBatchDownloadThread._sanitize_filename(str(on))
+                fn = (so.rsplit(".", 1)[0] + "_批阅." + so.rsplit(".", 1)[1]
+                      if "." in so and not so.endswith(".") else so + "_批阅")
+                files.append((url, f"批阅_{fn}", f"{activity_title}_批阅_{fn}", safe_title))
+
+    @staticmethod
+    def _collect_replay_videos(files, detail, safe_title, activity_title):
+        for v in (detail.get("replay_videos") or []):
+            if not isinstance(v, dict):
+                continue
+            url = v.get("download_url") or v.get("play_url")
+            if not isinstance(url, str) or not url:
+                continue
+            label = format_replay_video_label(v.get("label"))
+            fn = f"{label}_{common_format_size(v.get('size', 0))}.mp4"
+            files.append((url, fn, f"{activity_title}_{label}", safe_title))
+
+    # ──────────── Phase 2: 下载 ────────────
+
+    def _download_all(self, files: list):
+        self._total_jobs = len(files)
+        self._success_count = self._fail_count = self._completed_jobs = 0
+
+        self.titleChanged.emit(self.tr("正在下载"))
         self.messageChanged.emit(self.tr("0 / {0} 已完成").format(self._total_jobs))
         self.maximumChanged.emit(self._total_jobs)
         self.progressChanged.emit(0)
+
+        for url, fn, label, safe_title in files:
+            self._jobs.append(_DownloadJob(url, self._output_path(fn, safe_title), label, self._session))
 
         while self._jobs and self.can_run:
             with self._lock:
                 while len(self._active_workers) < self.max_concurrent() and self._jobs and self.can_run:
                     job = self._jobs.popleft()
-                    worker = _WorkerThread(job, self)
-                    worker.finished.connect(self._onWorkerFinished)
-                    self._active_workers.append(worker)
-                    worker.start()
+                    w = _WorkerThread(job)
+                    w.finished.connect(self._onWorkerFinished)
+                    self._active_workers.append(w)
+                    w.start()
                     self.fileStarted.emit(job.file_label)
-
-            # 短暂休眠让出 CPU，等 finished 信号回调清理
             self.msleep(100)
 
-        # 等待所有剩余线程结束
         with self._lock:
-            remaining = list(self._active_workers)
-        for worker in remaining:
-            worker.wait()
+            rem = list(self._active_workers)
+        for w in rem:
+            w.wait()
         with self._lock:
             self._active_workers.clear()
 
@@ -111,46 +283,50 @@ class LMSBatchDownloadThread(ProgressBarThread):
             return
 
         self.progressChanged.emit(self._total_jobs)
-        self.messageChanged.emit(
-            self.tr("{0} / {1} 已完成").format(self._total_jobs, self._total_jobs)
-        )
+        self.messageChanged.emit(self.tr("{0} / {1} 已完成").format(self._total_jobs, self._total_jobs))
         self.allCompleted.emit(self._success_count, self._fail_count)
         self.hasFinished.emit()
 
     def _onWorkerFinished(self):
-        """单个工作线程完成回调。"""
-        worker: _WorkerThread = self.sender()
-        if worker is None:
+        w = self.sender()
+        if w is None:
             return
-
         with self._lock:
             self._completed_jobs += 1
-            if worker.success:
+            if w.success:
                 self._success_count += 1
             else:
                 self._fail_count += 1
-            completed = self._completed_jobs
-            if worker in self._active_workers:
-                self._active_workers.remove(worker)
-
-        self.progressChanged.emit(completed)
-        self.messageChanged.emit(
-            self.tr("{0} / {1} 已完成").format(completed, self._total_jobs)
-        )
-        self.fileCompleted.emit(worker.job.file_label, worker.success, worker.error_msg)
+            n = self._completed_jobs
+            if w in self._active_workers:
+                self._active_workers.remove(w)
+        self.progressChanged.emit(n)
+        self.messageChanged.emit(self.tr("{0} / {1} 已完成").format(n, self._total_jobs))
+        self.fileCompleted.emit(w.job.file_label, w.success, w.error_msg)
 
     def onStopSignal(self):
-        """停止所有下载。"""
         super().onStopSignal()
         with self._lock:
             workers = list(self._active_workers)
-        for worker in workers:
-            worker.stop()
+        for w in workers:
+            w.stop()
+
+    @staticmethod
+    def _extract_error_msg(e: Exception) -> str:
+        """从网络异常中提取人类可读的错误信息。"""
+        # 优先解析响应体 JSON 中的 msg 字段
+        if hasattr(e, "response") and e.response is not None:
+            try:
+                body = e.response.json()
+                msg = body.get("msg", "") if isinstance(body, dict) else ""
+                if msg:
+                    return msg
+            except Exception:
+                pass
+        return str(e)
 
 
 class _WorkerThread(QThread):
-    """单个文件下载工作线程。"""
-
     def __init__(self, job: _DownloadJob, parent=None):
         super().__init__(parent)
         self.job = job
@@ -162,15 +338,19 @@ class _WorkerThread(QThread):
         self._can_run = False
 
     def run(self):
-        response = None
+        resp = None
         try:
-            response = self.job.session.get(self.job.url, stream=True, timeout=60)
-            response.raise_for_status()
+            # 检查路径合法性
+            if not self.job.output_path or not self.job.output_path.strip():
+                raise ValueError(self.tr("下载路径为空"))
+            if not os.path.isabs(self.job.output_path):
+                raise ValueError(self.tr("下载路径不是绝对路径: {0}").format(self.job.output_path))
 
+            resp = self.job.session.get(self.job.url, stream=True, timeout=60)
+            resp.raise_for_status()
             os.makedirs(os.path.dirname(self.job.output_path), exist_ok=True)
-
             with open(self.job.output_path, "wb") as f:
-                for chunk in response.iter_content(chunk_size=8192):
+                for chunk in resp.iter_content(chunk_size=8192):
                     if not self._can_run:
                         self._cleanup()
                         self.success = False
@@ -179,22 +359,17 @@ class _WorkerThread(QThread):
                     if not chunk:
                         continue
                     f.write(chunk)
-
             self.success = True
         except Exception as e:
-            import logging
-            logging.getLogger("default").exception(
-                "批量下载失败: %s -> %s", self.job.url, self.job.output_path
-            )
+            logger.exception("下载失败: %s -> %s", self.job.url, self.job.output_path)
             self._cleanup()
             self.success = False
-            self.error_msg = str(e)
+            self.error_msg = LMSBatchDownloadThread._extract_error_msg(e)
         finally:
-            if response is not None:
-                response.close()
+            if resp is not None:
+                resp.close()
 
     def _cleanup(self):
-        """删除不完整的文件。"""
         if self.job.output_path and os.path.exists(self.job.output_path):
             try:
                 os.remove(self.job.output_path)

--- a/app/threads/LMSBatchDownloadThread.py
+++ b/app/threads/LMSBatchDownloadThread.py
@@ -6,6 +6,7 @@ from collections import deque
 from PyQt5.QtCore import pyqtSignal, QThread
 
 from ..components.ProgressInfoBar import ProgressBarThread
+from ..utils import cfg
 
 
 class _DownloadJob:
@@ -51,7 +52,9 @@ class LMSBatchDownloadThread(ProgressBarThread):
     # 全部完成时发出 (success_count, fail_count)
     allCompleted = pyqtSignal(int, int)
 
-    MAX_CONCURRENT = 4  # 最大并发数
+    @staticmethod
+    def max_concurrent() -> int:
+        return max(1, min(10, cfg.lmsBatchDownloadConcurrency.value))
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -84,7 +87,7 @@ class LMSBatchDownloadThread(ProgressBarThread):
 
         while self._jobs and self.can_run:
             with self._lock:
-                while len(self._active_workers) < self.MAX_CONCURRENT and self._jobs and self.can_run:
+                while len(self._active_workers) < self.max_concurrent() and self._jobs and self.can_run:
                     job = self._jobs.popleft()
                     worker = _WorkerThread(job, self)
                     worker.finished.connect(self._onWorkerFinished)

--- a/app/threads/LMSBatchDownloadThread.py
+++ b/app/threads/LMSBatchDownloadThread.py
@@ -9,8 +9,7 @@ from PyQt5.QtCore import pyqtSignal, QThread
 
 from ..components.ProgressInfoBar import ProgressBarThread
 from ..sub_interfaces.lms.common import format_size as common_format_size, format_replay_video_label
-from ..utils import cfg, accounts
-from ..sessions.lms_session import LMSSession
+from ..utils import cfg
 from lms import LMSUtil
 from lms.models import ActivityType
 
@@ -42,7 +41,18 @@ class LMSBatchDownloadThread(ProgressBarThread):
                  target_dir, layout_mode,
                  download_uploads=True, download_submissions=True, download_marked=False,
                  parent=None):
-        super().__init__(parent)
+        """初始化批量下载线程。
+
+        :param selected_activities: 用户选中的活动字典列表。
+        :param activity_type: 当前 tab 的活动类型。
+        :param account: 当前登录账户对象。
+        :param target_dir: 下载目标目录。
+        :param layout_mode: "flat" 统一存放，"hierarchical" 按活动存放。
+        :param download_uploads: 是否下载作业附件。
+        :param download_submissions: 是否下载提交附件。
+        :param download_marked: 是否下载批阅附件。
+        :param parent: 父级控件。
+        """
         self._selected_activities = [dict(a) for a in selected_activities if isinstance(a, dict)]
         self._activity_type = activity_type
         self._account = account
@@ -111,7 +121,7 @@ class LMSBatchDownloadThread(ProgressBarThread):
     # ──────────── Phase 1: 收集 ────────────
 
     def _collect_all(self) -> list:
-        total = len(self._selected_activities)
+        """遍历选中活动，逐一获取详情并收集附件文件列表。"""
         files: list = []
 
         for idx, activity in enumerate(self._selected_activities, start=1):
@@ -155,12 +165,18 @@ class LMSBatchDownloadThread(ProgressBarThread):
 
     @staticmethod
     def _sanitize_filename(name: str) -> str:
+        """清理文件名中的非法字符。"""
         cleaned = re.sub(r'[\\/:*?"<>|]+', "_", name)
         cleaned = cleaned.strip().strip(".")
         return cleaned or "file"
 
     def _output_path(self, file_name: str, safe_activity_title: str) -> str:
-        safe = self._sanitize_filename(file_name)
+        """根据布局模式构建输出路径。
+
+        :param file_name: 文件名。
+        :param safe_activity_title: 已清理非法字符的活动标题。
+        :return: 完整的输出文件绝对路径。
+        """
         if self._layout_mode == "hierarchical":
             sub = os.path.join(self._target_dir, safe_activity_title)
             os.makedirs(sub, exist_ok=True)
@@ -169,6 +185,7 @@ class LMSBatchDownloadThread(ProgressBarThread):
 
     @staticmethod
     def _collect_uploads(files, detail, safe_title, activity_title):
+        """收集活动附件（教师上传的题目附件）。"""
         for upload in (detail.get("uploads") or []):
             if not isinstance(upload, dict):
                 continue
@@ -180,6 +197,7 @@ class LMSBatchDownloadThread(ProgressBarThread):
 
     @staticmethod
     def _collect_submission_uploads(files, detail, safe_title, activity_title):
+        """收集提交附件（学生提交的作业文件）。"""
         sl = detail.get("submission_list")
         if not isinstance(sl, dict):
             return
@@ -204,6 +222,7 @@ class LMSBatchDownloadThread(ProgressBarThread):
 
     @staticmethod
     def _collect_marked_attachments(files, detail, safe_title, activity_title, util):
+        """收集批阅附件（老师批改后的标注文件）。"""
         sl = detail.get("submission_list")
         if not isinstance(sl, dict):
             return
@@ -236,6 +255,7 @@ class LMSBatchDownloadThread(ProgressBarThread):
 
     @staticmethod
     def _collect_replay_videos(files, detail, safe_title, activity_title):
+        """收集回放视频。"""
         for v in (detail.get("replay_videos") or []):
             if not isinstance(v, dict):
                 continue
@@ -249,7 +269,7 @@ class LMSBatchDownloadThread(ProgressBarThread):
     # ──────────── Phase 2: 下载 ────────────
 
     def _download_all(self, files: list):
-        self._total_jobs = len(files)
+        """执行多文件并发下载。"""
         self._success_count = self._fail_count = self._completed_jobs = 0
 
         self.titleChanged.emit(self.tr("正在下载"))
@@ -288,7 +308,7 @@ class LMSBatchDownloadThread(ProgressBarThread):
         self.hasFinished.emit()
 
     def _onWorkerFinished(self):
-        w = self.sender()
+        """单个工作线程完成回调。"""
         if w is None:
             return
         with self._lock:
@@ -305,7 +325,7 @@ class LMSBatchDownloadThread(ProgressBarThread):
         self.fileCompleted.emit(w.job.file_label, w.success, w.error_msg)
 
     def onStopSignal(self):
-        super().onStopSignal()
+        """停止所有下载。"""
         with self._lock:
             workers = list(self._active_workers)
         for w in workers:
@@ -327,6 +347,8 @@ class LMSBatchDownloadThread(ProgressBarThread):
 
 
 class _WorkerThread(QThread):
+    """单个文件下载工作线程。"""
+
     def __init__(self, job: _DownloadJob, parent=None):
         super().__init__(parent)
         self.job = job
@@ -335,6 +357,7 @@ class _WorkerThread(QThread):
         self._can_run = True
 
     def stop(self):
+        """请求停止当前下载。"""
         self._can_run = False
 
     def run(self):
@@ -370,6 +393,7 @@ class _WorkerThread(QThread):
                 resp.close()
 
     def _cleanup(self):
+        """删除下载过程中残留的不完整文件。"""
         if self.job.output_path and os.path.exists(self.job.output_path):
             try:
                 os.remove(self.job.output_path)

--- a/app/threads/LMSBatchDownloadThread.py
+++ b/app/threads/LMSBatchDownloadThread.py
@@ -177,6 +177,7 @@ class LMSBatchDownloadThread(ProgressBarThread):
         :param safe_activity_title: 已清理非法字符的活动标题。
         :return: 完整的输出文件绝对路径。
         """
+        safe = self._sanitize_filename(file_name)
         if self._layout_mode == "hierarchical":
             sub = os.path.join(self._target_dir, safe_activity_title)
             os.makedirs(sub, exist_ok=True)
@@ -270,6 +271,7 @@ class LMSBatchDownloadThread(ProgressBarThread):
 
     def _download_all(self, files: list):
         """执行多文件并发下载。"""
+        self._total_jobs = len(files)
         self._success_count = self._fail_count = self._completed_jobs = 0
 
         self.titleChanged.emit(self.tr("正在下载"))
@@ -309,6 +311,7 @@ class LMSBatchDownloadThread(ProgressBarThread):
 
     def _onWorkerFinished(self):
         """单个工作线程完成回调。"""
+        w = self.sender()
         if w is None:
             return
         with self._lock:

--- a/app/threads/LMSBatchDownloadThread.py
+++ b/app/threads/LMSBatchDownloadThread.py
@@ -53,6 +53,7 @@ class LMSBatchDownloadThread(ProgressBarThread):
         :param download_marked: 是否下载批阅附件。
         :param parent: 父级控件。
         """
+        super().__init__(parent)
         self._selected_activities = [dict(a) for a in selected_activities if isinstance(a, dict)]
         self._activity_type = activity_type
         self._account = account
@@ -122,6 +123,7 @@ class LMSBatchDownloadThread(ProgressBarThread):
 
     def _collect_all(self) -> list:
         """遍历选中活动，逐一获取详情并收集附件文件列表。"""
+        total = len(self._selected_activities)
         files: list = []
 
         for idx, activity in enumerate(self._selected_activities, start=1):

--- a/app/threads/LMSFileDownloadThread.py
+++ b/app/threads/LMSFileDownloadThread.py
@@ -1,3 +1,4 @@
+import json
 import os
 
 from ..components.ProgressInfoBar import ProgressBarThread
@@ -29,6 +30,12 @@ class LMSFileDownloadThread(ProgressBarThread):
     def run(self):
         response = None
         try:
+            # 检查路径合法性
+            if not self.output_path or not self.output_path.strip():
+                raise ValueError(self.tr("下载路径为空"))
+            if not os.path.isabs(self.output_path):
+                raise ValueError(self.tr("下载路径不是绝对路径: {0}").format(self.output_path))
+
             self.titleChanged.emit(self.tr("正在下载附件"))
             self.messageChanged.emit(self.tr("准备下载：{0}").format(self.file_label))
             self.maximumChanged.emit(100)
@@ -76,7 +83,16 @@ class LMSFileDownloadThread(ProgressBarThread):
             self.canceled.emit()
         except Exception as e:
             self._remove_partial_file()
-            self.error.emit(self.tr("下载失败"), str(e))
+            msg = str(e)
+            if hasattr(e, "response") and e.response is not None:
+                try:
+                    body = e.response.json()
+                    json_msg = body.get("msg", "") if isinstance(body, dict) else ""
+                    if json_msg:
+                        msg = json_msg
+                except Exception:
+                    pass
+            self.error.emit(self.tr("下载失败"), msg)
             self.canceled.emit()
         finally:
             if response is not None:

--- a/app/utils/config.py
+++ b/app/utils/config.py
@@ -280,6 +280,9 @@ class Config(QConfig):
     # 是否启用思源学堂课程/作业缓存
     lmsCacheEnable = OptionsConfigItem("Settings", "lms_cache_enable",
                                        True, OptionsValidator([True, False]), BooleanSerializer())
+    lmsBatchDownloadConcurrency = OptionsConfigItem("Settings", "lms_batch_concurrency",
+                                                    4, OptionsValidator([1, 2, 3, 4, 5, 6]),
+                                                    None)
     autoRetryAttendance = OptionsConfigItem("Settings", "auto_retry_attendance",
                                             True, OptionsValidator([True, False]), BooleanSerializer())
     traySetting = OptionsConfigItem("Settings", "tray_setting",


### PR DESCRIPTION
支持在思源学堂活动列表页批量下载课程资料。进入选择模式后勾选多个活动，一键下载所选附件。

### 交互方式

- 活动页顶栏新增「选择」按钮，点击进入选择模式
- 选择模式下，活动卡片左侧出现勾选框（直播活动不可选），点击卡片也可切换勾选
- 底部控制栏提供「全选」「批量下载」和选中计数，点击「取消选择」或切换标签页退出选择模式

### 各标签页下载内容

| 标签页 | 支持批量下载 | 下载内容 |
|--------|------------|---------|
| 作业 | ✅ | 可选三种类型：作业附件（教师上传）、提交附件（学生提交）、批阅附件（批改标注） |
| 资料 | ✅ | 活动附件 |
| 课程回放 | ✅ | 回放视频 |
| 直播 | ❌ | — |

### 下载设置

- 目录布局：统一存放 或 按活动名称分文件夹存放
- 并发数：1-6 可调（设置页 → 思源学堂 → 批量下载并发数，默认 4）
