### PR TITLE
feat: 教师主页检索与轻解析

### DIFF
--- a/app/FacultyInterface.py
+++ b/app/FacultyInterface.py
@@ -1,0 +1,187 @@
+from PyQt5.QtCore import QUrl, Qt
+from PyQt5.QtGui import QDesktopServices
+from PyQt5.QtWidgets import QFrame, QTableWidgetItem, QVBoxLayout
+from qfluentwidgets import BodyLabel, CaptionLabel, ComboBox, HyperlinkButton, LineEdit, PrimaryPushButton, PushButton
+
+from faculty import Faculty, HomepageResult, extra_fields, group_columns
+from .components.CampusPage import CampusPage
+
+
+class FacultyInterface(CampusPage):
+    def __init__(self, parent=None):
+        super().__init__("facultyInterface", "教师主页", "检索教师，点选后轻解析个人主页；无需登录", parent)
+        self.members = []
+        self._filters_loaded = False
+        self._current = None
+
+        self.nameEdit = LineEdit(self.view)
+        self.nameEdit.setPlaceholderText(self.tr("姓名，可留空"))
+        self.nameEdit.setMinimumWidth(160)
+        self.nameEdit.returnPressed.connect(self.search)
+        self.collegeBox = ComboBox(self.view)
+        self.collegeBox.setMinimumWidth(220)
+        self.collegeBox.addItem(self.tr("全部学院"), userData="0")
+        self.searchButton = PrimaryPushButton(self.tr("搜索"), self.view)
+        self.searchButton.setFixedWidth(96)
+        self.searchButton.clicked.connect(self.search)
+        self.add_toolbar(
+            self.labeled(self.tr("姓名"), self.nameEdit),
+            self.labeled(self.tr("学院"), self.collegeBox),
+            self.searchButton,
+        )
+
+        self.table = self.make_table([
+            self.tr("姓名"), self.tr("学院"), self.tr("职称"), self.tr("导师"), self.tr("研究方向"),
+        ])
+        self.table.itemSelectionChanged.connect(self._on_select)
+        self.vBoxLayout.addWidget(self.table, 2)
+
+        self.detail = QFrame(self.view)
+        self.detailLayout = QVBoxLayout(self.detail)
+        self.detailLayout.setContentsMargins(8, 8, 8, 8)
+        self.detailLayout.setSpacing(6)
+        self.nameLabel = BodyLabel(self.tr("在上方搜索后，点选一位教师查看详情。"), self.detail)
+        self.nameLabel.setWordWrap(True)
+        self.metaLabel = CaptionLabel("", self.detail)
+        self.metaLabel.setWordWrap(True)
+        self.fieldsLabel = BodyLabel("", self.detail)
+        self.fieldsLabel.setWordWrap(True)
+        self.fieldsLabel.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        self.homepageLabel = CaptionLabel("", self.detail)
+        self.homepageLabel.setWordWrap(True)
+        self.extraLabel = BodyLabel("", self.detail)
+        self.extraLabel.setWordWrap(True)
+        self.extraLabel.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        self.columnBox = QFrame(self.detail)
+        self.columnLayout = QVBoxLayout(self.columnBox)
+        self.columnLayout.setContentsMargins(0, 0, 0, 0)
+        self.columnLayout.setSpacing(2)
+        self.openButton = PushButton(self.tr("在浏览器中打开个人主页"), self.detail)
+        self.openButton.setEnabled(False)
+        self.openButton.clicked.connect(self.open_homepage)
+        self.detailLayout.addWidget(self.nameLabel)
+        self.detailLayout.addWidget(self.metaLabel)
+        self.detailLayout.addWidget(self.fieldsLabel)
+        self.detailLayout.addWidget(self.homepageLabel)
+        self.detailLayout.addWidget(self.extraLabel)
+        self.detailLayout.addWidget(self.columnBox)
+        self.detailLayout.addWidget(self.openButton, alignment=Qt.AlignLeft)
+        self.vBoxLayout.addWidget(self.detail, 1)
+
+    def showEvent(self, event):
+        super().showEvent(event)
+        if self._filters_loaded:
+            return
+        self._filters_loaded = True
+        self.start_job("faculty", self.tr("正在加载学院列表..."), lambda _: Faculty().load_filters(), self._on_filters, need_login=False)
+
+    def search(self):
+        name = self.nameEdit.text().strip()
+        college_id = self.collegeBox.currentData() or "0"
+        self.start_job(
+            "faculty",
+            self.tr("正在搜索教师..."),
+            lambda _: Faculty().search(name, college_id),
+            self._on_result,
+            need_login=False,
+        )
+
+    def _on_filters(self, filters):
+        current = self.collegeBox.currentData() or "0"
+        self.collegeBox.clear()
+        self.collegeBox.addItem(self.tr("全部学院"), userData="0")
+        for college_id, name in filters.colleges:
+            self.collegeBox.addItem(name, userData=college_id)
+        for index in range(self.collegeBox.count()):
+            if self.collegeBox.itemData(index) == current:
+                self.collegeBox.setCurrentIndex(index)
+                break
+
+    def _on_result(self, payload):
+        total, members = payload
+        self.members = members
+        self.table.setRowCount(len(members))
+        for row, member in enumerate(members):
+            self.table.setItem(row, 0, QTableWidgetItem(member.name))
+            self.table.setItem(row, 1, QTableWidgetItem(member.college))
+            self.table.setItem(row, 2, QTableWidgetItem(member.rank))
+            self.table.setItem(row, 3, QTableWidgetItem(member.tutor_label))
+            self.table.setItem(row, 4, QTableWidgetItem(member.research or member.discipline))
+        self.table.resizeRowsToContents()
+        self.success(self.tr("查询成功"), self.tr("共 {total} 人").format(total=total))
+
+    def _on_select(self):
+        row = self.table.currentRow()
+        if row < 0 or row >= len(self.members):
+            return
+        member = self.members[row]
+        self._current = member
+        self.openButton.setEnabled(bool(member.url))
+        meta = " · ".join(part for part in (member.rank, member.tutor_label, member.college, member.english_name) if part)
+        self.nameLabel.setText(member.name or self.tr("未知名"))
+        self.metaLabel.setText(meta)
+        basics = member.basics()
+        if member.profile:
+            basics.append((self.tr("简介"), member.profile))
+        self.fieldsLabel.setText("\n".join(f"{label}：{value}" for label, value in basics) if basics else "")
+        self.homepageLabel.setText(self.tr("正在轻解析个人主页…") if member.has_standard_homepage else "")
+        self.extraLabel.setText("")
+        self._clear_columns()
+        if member.has_standard_homepage:
+            self.start_job(
+                "faculty",
+                self.tr("正在轻解析个人主页..."),
+                lambda _: Faculty().fetch_homepage(member.url),
+                lambda result, current=member: self._on_homepage(current, result),
+                need_login=False,
+            )
+        elif member.url:
+            self.homepageLabel.setText(self.tr("这位老师的主页地址指向站外页面，只能直接打开查看。"))
+        else:
+            self.homepageLabel.setText(self.tr("没有个人主页地址。"))
+
+    def _on_homepage(self, member, result: HomepageResult):
+        if self._current is None or member.teacher_id != self._current.teacher_id:
+            return
+        if result.kind == "unavailable":
+            self.homepageLabel.setText(self.tr("这位老师还没有启用个人主页。"))
+            return
+        if result.kind == "not_standard":
+            self.homepageLabel.setText(self.tr("这位老师的主页地址指向站外页面，只能直接打开查看。"))
+            return
+        if result.kind == "error" or result.profile is None:
+            self.homepageLabel.setText(self.tr("个人主页暂时打不开：{msg}").format(msg=result.message or ""))
+            return
+
+        basics = member.basics()
+        known_labels = {label for label, _value in basics}
+        known_labels.update({"职称", "所在单位", "博士生导师", "硕士生导师", "个人主页"})
+        known_values = {value for _label, value in basics}
+        known_values.update(part for part in (member.rank, member.college, member.url, member.name) if part)
+        extra = extra_fields(result.profile.fields, known_labels, known_values)
+        self.homepageLabel.setText(
+            self.tr("主页补充") if extra or result.profile.columns else self.tr("主页没有更多可解析字段。")
+        )
+        self.extraLabel.setText("\n".join(f"{label}：{value}" for label, value in extra))
+        self._clear_columns()
+        for group in group_columns(result.profile.columns):
+            self._add_column_link(group.section)
+            for child in group.children:
+                self._add_column_link(child, indent=True)
+
+    def _add_column_link(self, column, indent: bool = False):
+        button = HyperlinkButton(self.columnBox)
+        button.setText(("　　" if indent else "") + column.display_name)
+        button.setUrl(column.url)
+        self.columnLayout.addWidget(button, alignment=Qt.AlignLeft)
+
+    def _clear_columns(self):
+        while self.columnLayout.count():
+            item = self.columnLayout.takeAt(0)
+            widget = item.widget()
+            if widget is not None:
+                widget.deleteLater()
+
+    def open_homepage(self):
+        if self._current and self._current.url:
+            QDesktopServices.openUrl(QUrl(self._current.url))

--- a/app/HomeInterface.py
+++ b/app/HomeInterface.py
@@ -198,6 +198,13 @@ class HomeFrame(QWidget):
                 'content': self.tr("查看作业、课件与课程回放"),
                 'callback': lambda: self.main_window.switchTo(self.main_window.lms_interface),
                 'color': LinkCard.LinkCardColor.SKY_BLUE
+            },
+            "faculty": {
+                'icon': FIF.EDUCATION.icon(theme=Theme.DARK),
+                'title': self.tr("教师主页"),
+                'content': self.tr("检索教师主页"),
+                'callback': lambda: self.main_window.switchTo(self.main_window.faculty_interface),
+                'color': LinkCard.LinkCardColor.SKY_BLUE
             }
         }
 

--- a/app/components/CampusPage.py
+++ b/app/components/CampusPage.py
@@ -1,0 +1,113 @@
+from PyQt5.QtWidgets import QFrame, QHBoxLayout, QHeaderView, QVBoxLayout, QWidget
+from qfluentwidgets import BodyLabel, InfoBar, InfoBarPosition, ScrollArea, StrongBodyLabel, TableWidget, TitleLabel
+
+from app.threads.CampusFeatureThread import CampusFeatureThread
+from app.threads.ProcessWidget import ProcessWidget
+from app.utils import StyleSheet, accounts
+
+
+class CampusPage(ScrollArea):
+    """Shared chrome for newly ported campus tools."""
+
+    def __init__(self, object_name: str, title: str, subtitle: str, parent=None):
+        super().__init__(parent)
+        self.setObjectName(object_name)
+        self.view = QWidget(self)
+        self.view.setObjectName("view")
+        self.vBoxLayout = QVBoxLayout(self.view)
+        self.vBoxLayout.setContentsMargins(24, 24, 24, 40)
+        self.vBoxLayout.setSpacing(10)
+        self.titleLabel = TitleLabel(title, self.view)
+        self.titleLabel.setContentsMargins(10, 15, 0, 0)
+        self.vBoxLayout.addWidget(self.titleLabel)
+        self.minorLabel = StrongBodyLabel(subtitle, self.view)
+        self.minorLabel.setContentsMargins(15, 5, 0, 0)
+        self.vBoxLayout.addWidget(self.minorLabel)
+
+        self.jobSlot = QWidget(self.view)
+        self.jobLayout = QVBoxLayout(self.jobSlot)
+        self.jobLayout.setContentsMargins(0, 0, 0, 0)
+        self.jobLayout.setSpacing(0)
+        self.vBoxLayout.addWidget(self.jobSlot)
+        self.thread = None
+        self.processWidget = None
+
+        StyleSheet.EMPTY_ROOM_INTERFACE.apply(self)
+        self.setWidgetResizable(True)
+        self.setWidget(self.view)
+        self._notice = None
+
+    def add_toolbar(self, *widgets) -> QFrame:
+        bar = QFrame(self.view)
+        layout = QHBoxLayout(bar)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(8)
+        for widget in widgets:
+            if widget is not None:
+                layout.addWidget(widget)
+        layout.addStretch(1)
+        self.vBoxLayout.addWidget(bar)
+        return bar
+
+    def labeled(self, text: str, widget: QWidget, width: int = 56) -> QFrame:
+        box = QFrame(self.view)
+        layout = QHBoxLayout(box)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(6)
+        label = BodyLabel(text, box)
+        label.setFixedWidth(width)
+        layout.addWidget(label)
+        layout.addWidget(widget)
+        return box
+
+    def make_table(self, headers: list[str]) -> TableWidget:
+        table = TableWidget(self.view)
+        table.setColumnCount(len(headers))
+        table.setHorizontalHeaderLabels(headers)
+        table.horizontalHeader().setSectionResizeMode(QHeaderView.ResizeToContents)
+        table.horizontalHeader().setStretchLastSection(True)
+        table.verticalHeader().setVisible(False)
+        table.setEditTriggers(TableWidget.NoEditTriggers)
+        table.setWordWrap(True)
+        table.setAlternatingRowColors(True)
+        table.setSelectionBehavior(TableWidget.SelectRows)
+        return table
+
+    def start_job(self, site_key: str, message: str, worker, on_result, need_login: bool = True,
+                  show_process: bool = True) -> bool:
+        if self.thread is not None and self.thread.isRunning():
+            self.thread.can_run = False
+        self.thread = CampusFeatureThread(site_key, message, worker, need_login=need_login, parent=self)
+        if self.processWidget:
+            self.processWidget.deleteLater()
+            self.processWidget = None
+        if show_process:
+            self.processWidget = ProcessWidget(self.thread, self.jobSlot, hide_on_end=True)
+            self.jobLayout.addWidget(self.processWidget)
+        self.thread.result.connect(on_result)
+        self.thread.error.connect(self.warn)
+        self.thread.start()
+        return True
+
+    def require_account(self) -> bool:
+        if accounts.current is None:
+            self.warn(self.tr("未登录"), self.tr("请先添加一个账户"))
+            return False
+        return True
+
+    def info(self, title: str, msg: str) -> None:
+        self._bar(InfoBar.info, title, msg)
+
+    def success(self, title: str, msg: str) -> None:
+        self._bar(InfoBar.success, title, msg)
+
+    def warn(self, title: str, msg: str) -> None:
+        self._bar(InfoBar.warning, title, msg)
+
+    def _bar(self, factory, title: str, msg: str) -> None:
+        if self._notice is not None:
+            try:
+                self._notice.close()
+            except RuntimeError:
+                self._notice = None
+        self._notice = factory(title, msg, duration=2500, position=InfoBarPosition.TOP_RIGHT, parent=self)

--- a/app/main_window.py
+++ b/app/main_window.py
@@ -32,6 +32,7 @@ from .sessions.gste_session import GSTESession
 from .sessions.jwapp_session import JwappSession
 from .sessions.lms_session import LMSSession
 from .sessions.venue_session import VenueSession
+from .FacultyInterface import FacultyInterface
 from .sub_interfaces import LoginInterface
 from .sub_interfaces.QRCodeLoginDialog import QRCodeLoginDialog
 from .sub_interfaces.VerifyCodeDialog import VerifyCodeDialog
@@ -202,6 +203,8 @@ class MainWindow(MSFluentWindow):
         QApplication.processEvents()
         self.venue_interface = VenueInterface(self)
         QApplication.processEvents()
+        self.faculty_interface = FacultyInterface(self)
+        QApplication.processEvents()
 
         self.tray_interface = TrayInterface(QIcon("assets/icons/main_icon.ico"))
         self.tray_interface.main_interface.connect(lambda: self.show())
@@ -363,6 +366,12 @@ class MainWindow(MSFluentWindow):
         empty_room_card = self.tool_box_interface.addCard(self.empty_room_interface, FIF.LAYOUT, self.tr("空闲教室"),
                                                           self.tr("查询当前空闲的教室"))
         empty_room_card.setFixedSize(200, 180)
+
+        faculty_card = self.tool_box_interface.addCard(
+            self.faculty_interface, FIF.EDUCATION, self.tr("教师主页"),
+            self.tr("检索教师主页"),
+        )
+        faculty_card.setFixedSize(200, 180)
 
         # 添加登录界面作为子界面，但是将其隐藏
         button = self.addSubInterface(self.login_interface, FIF.SCROLL, self.tr("登录"),

--- a/app/threads/CampusFeatureThread.py
+++ b/app/threads/CampusFeatureThread.py
@@ -1,0 +1,39 @@
+from collections.abc import Callable
+from typing import Any
+
+from PyQt5.QtCore import pyqtSignal
+
+from app.threads.ProcessWidget import ProcessThread
+from app.utils.campus_job import run_campus_job
+
+
+class CampusFeatureThread(ProcessThread):
+    """Login a campus site (optional) and run a worker on a background thread."""
+
+    result = pyqtSignal(object)
+
+    def __init__(
+            self,
+            site_key: str,
+            login_message: str,
+            worker: Callable[[Any], Any],
+            need_login: bool = True,
+            parent=None):
+        super().__init__(parent)
+        self.site_key = site_key
+        self.login_message = login_message
+        self.worker = worker
+        self.need_login = need_login
+
+    def run(self):
+        payload = run_campus_job(
+            self,
+            site_key=self.site_key,
+            login_message=self.login_message,
+            worker=self.worker,
+            need_login=self.need_login,
+        )
+        if payload is None:
+            return
+        self.result.emit(payload)
+        self.hasFinished.emit()

--- a/app/utils/campus_job.py
+++ b/app/utils/campus_job.py
@@ -1,0 +1,95 @@
+"""Shared login + error handling for campus feature worker threads."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import requests
+
+from auth import ServerError
+from app.threads.ProcessWidget import ProcessThread
+from app.utils import accounts, logger
+from app.utils.mfa import MFACancelledError, MFAUnavailableError
+from app.utils.qrcode_login import QRCodeLoginCancelledError, QRCodeLoginUnavailableError
+
+
+def run_campus_job(
+        thread: ProcessThread,
+        *,
+        site_key: str,
+        login_message: str,
+        worker: Callable[[Any], Any],
+        need_login: bool = True) -> Any:
+    """Login the current account into ``site_key`` (optional) and run ``worker``.
+
+    ``worker`` receives the site session (or ``None`` when ``need_login`` is false).
+    The function emits the usual ProcessThread error/cancel signals and returns
+    the worker result on success. The caller should emit ``result`` / ``hasFinished``.
+    """
+    thread.can_run = True
+    if need_login and accounts.current is None:
+        thread.error.emit(thread.tr("未登录"), thread.tr("请先添加一个账户"))
+        thread.canceled.emit()
+        return None
+
+    try:
+        session = None
+        if need_login:
+            session = accounts.current.session_manager.get_session(site_key)
+            thread.setIndeterminate.emit(True)
+            thread.messageChanged.emit(login_message)
+            session.ensure_login(
+                accounts.current.username,
+                accounts.current.password,
+                account=accounts.current,
+                mfa_provider=accounts.current.session_manager.mfa_provider,
+            )
+            if not thread.can_run:
+                thread.canceled.emit()
+                return None
+        result = worker(session)
+        if not thread.can_run:
+            thread.canceled.emit()
+            return None
+        return result
+    except QRCodeLoginCancelledError as e:
+        logger.info("二维码登录已取消：%s", e)
+        thread.error.emit(thread.tr("扫码登录已取消"), thread.tr("已取消扫码登录，本次操作未完成。"))
+        thread.canceled.emit()
+    except QRCodeLoginUnavailableError as e:
+        logger.error("二维码登录交互不可用", exc_info=True)
+        thread.error.emit(thread.tr("登录问题"), str(e))
+        thread.canceled.emit()
+    except MFACancelledError as e:
+        logger.info("MFA 验证已取消：%s", e)
+        thread.error.emit(thread.tr("安全验证已取消"), thread.tr("已取消安全验证，本次操作未完成。"))
+        thread.canceled.emit()
+    except MFAUnavailableError as e:
+        logger.error("MFA 交互不可用", exc_info=True)
+        thread.error.emit(thread.tr("登录问题"), str(e))
+        thread.canceled.emit()
+    except ServerError as e:
+        logger.error("服务器错误", exc_info=True)
+        if e.code == 102:
+            thread.error.emit(
+                thread.tr("登录问题"),
+                thread.tr("需要进行两步验证，请前往账户界面，选择对应账户进行验证。"),
+            )
+            accounts.current.MFASignal.emit(True)
+        else:
+            thread.error.emit(thread.tr("服务器错误"), e.message)
+        thread.canceled.emit()
+    except requests.ConnectionError:
+        logger.error("网络错误", exc_info=True)
+        thread.error.emit(thread.tr("无网络连接"), thread.tr("请检查网络连接，然后重试。"))
+        thread.canceled.emit()
+    except requests.RequestException as e:
+        logger.error("网络错误", exc_info=True)
+        thread.error.emit(thread.tr("网络错误"), str(e))
+        thread.canceled.emit()
+    except Exception as e:
+        logger.error("其他错误", exc_info=True)
+        thread.error.emit(thread.tr("其他错误"), str(e))
+        thread.canceled.emit()
+    return None

--- a/faculty/__init__.py
+++ b/faculty/__init__.py
@@ -1,0 +1,13 @@
+from .homepage import FacultyColumn, FacultyProfile, HomepageResult, extra_fields, group_columns
+from .search import Faculty, FacultyFilter, FacultyMember
+
+__all__ = [
+    "Faculty",
+    "FacultyColumn",
+    "FacultyFilter",
+    "FacultyMember",
+    "FacultyProfile",
+    "HomepageResult",
+    "extra_fields",
+    "group_columns",
+]

--- a/faculty/homepage.py
+++ b/faculty/homepage.py
@@ -1,0 +1,363 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+from lxml import html as lxml_html
+
+HOMEPAGE_HOST = "https://gr.xjtu.edu.cn"
+FACULTY_HOST = "https://faculty.xjtu.edu.cn"
+
+PROFILE_LABELS = (
+    "其他联系方式", "通讯/办公地址", "博士生导师", "硕士生导师",
+    "毕业院校", "所在单位", "电子邮箱", "办公地点", "联系方式", "入职时间",
+    "个人主页", "性别", "职称", "职务", "学历", "学位", "学科", "邮箱",
+)
+FIELD_BLOCK_STOPPERS = (
+    "访问量", "最后更新时间", "版权所有", "当前位置", "中文主页", "陕ICP备",
+    "主页", "基本信息", "个人简介", "校内登录", "手机版", "Personal profile",
+)
+SKIP_COLUMN_TITLES = {"首页", "中文主页", "英文主页", "English", "Home"}
+FIELD_ALIASES = {
+    "学科": {"学科"},
+    "学位": {"学位"},
+    "学历": {"学历"},
+    "毕业院校": {"毕业院校"},
+    "职务": {"职务"},
+    "办公地点": {"办公地点", "通讯/办公地址"},
+    "邮箱": {"邮箱", "电子邮箱"},
+    "联系方式": {"联系方式", "其他联系方式"},
+    "电话": {"电话"},
+    "通讯地址": {"通讯地址", "通讯/办公地址"},
+    "入职时间": {"入职时间"},
+    "职称": {"职称"},
+    "所在单位": {"所在单位"},
+    "性别": {"性别"},
+}
+FIELD_CLUSTER_GAP = 220
+FIELD_VALUE_MAX = 120
+ENCRYPTED_VALUE_RE = re.compile(r"^[0-9a-f]{32,}$", re.IGNORECASE)
+TEMPLATE_RE = re.compile(r"jszy_?([a-z0-9]+)")
+COLUMN_URL_RE = re.compile(r"/([A-Za-z0-9._-]+)/zh_CN/([a-z]+)/(\d+)/list/index\.htm")
+OPTION_PREFIX_RE = re.compile(r"^[|\-\s]+")
+
+COLUMN_NAMES = {
+    "article": "我的新闻",
+    "kyxm": "科研项目",
+    "lwcg": "论文成果",
+    "zlcg": "专利成果",
+    "zzcg": "著作成果",
+    "hjxx": "获奖信息",
+    "zsxx": "招生信息",
+    "yjgk": "研究领域",
+    "jxcg": "教学成果",
+    "jxzy": "教学资源",
+    "skxx": "授课信息",
+    "xsxx": "学生信息",
+    "img": "我的相册",
+    "index": "首页",
+    "zhym": "综合页面",
+    "zdylm": "自定义栏目",
+}
+USER_NAMED_COLUMNS = {"zhym", "zdylm"}
+
+
+@dataclass
+class FacultyColumn:
+    type: str
+    column_id: str
+    url: str
+    title: str = ""
+    depth: int = 0
+    parent_id: str | None = None
+
+    @property
+    def display_name(self) -> str:
+        type_name = COLUMN_NAMES.get(self.type)
+        if self.type in USER_NAMED_COLUMNS:
+            return self.title or type_name or self.type
+        return type_name or self.title or self.type
+
+
+@dataclass
+class FacultyColumnGroup:
+    section: FacultyColumn
+    children: list[FacultyColumn] = field(default_factory=list)
+
+
+@dataclass
+class FacultyProfile:
+    template: str = ""
+    title_name: str = ""
+    fields: dict[str, str] = field(default_factory=dict)
+    columns: list[FacultyColumn] = field(default_factory=list)
+
+
+@dataclass
+class HomepageResult:
+    kind: str
+    message: str = ""
+    profile: FacultyProfile | None = None
+    url: str = ""
+
+    @classmethod
+    def success(cls, profile: FacultyProfile, url: str) -> HomepageResult:
+        return cls("success", profile=profile, url=url)
+
+    @classmethod
+    def not_standard(cls, url: str) -> HomepageResult:
+        return cls("not_standard", url=url)
+
+    @classmethod
+    def unavailable(cls) -> HomepageResult:
+        return cls("unavailable")
+
+    @classmethod
+    def error(cls, message: str) -> HomepageResult:
+        return cls("error", message=message)
+
+
+def decode_page(content: bytes) -> str:
+    """gr.xjtu.edu.cn often omits charset; requests then falls back to Latin-1."""
+    if content.startswith(b"\xef\xbb\xbf"):
+        return content.decode("utf-8-sig")
+    try:
+        text = content.decode("utf-8")
+        if "\ufffd" not in text:
+            return text
+    except UnicodeDecodeError:
+        pass
+    return content.decode("gb18030", errors="replace")
+
+
+def looks_mojibake(text: str) -> bool:
+    if not text:
+        return False
+    marks = sum(ch in "åæçèøÿÃÂÐÑ" or ch == "\ufffd" for ch in text)
+    cjk = sum("\u4e00" <= ch <= "\u9fff" for ch in text)
+    return marks >= 2 and marks > cjk
+
+
+def is_standard_homepage(url: str) -> bool:
+    return url.startswith(f"{HOMEPAGE_HOST}/") and url.endswith("/zh_CN/index.htm")
+
+
+def looks_like_json(body: str) -> bool:
+    stripped = body.lstrip()
+    return bool(stripped) and stripped[0] in "{["
+
+
+def absolute_url(path: str, host: str = HOMEPAGE_HOST) -> str:
+    if not path:
+        return ""
+    if path.startswith(("http://", "https://")):
+        return path
+    if path.startswith("//"):
+        return "https:" + path
+    if path.startswith("/"):
+        return host + path
+    return f"{host}/{path}"
+
+
+def is_unavailable_page(html: str) -> bool:
+    if not html.strip():
+        return True
+    if len(html) > 2000:
+        return False
+    match = re.search(r"<title>(.*?)</title>", html, re.DOTALL | re.IGNORECASE)
+    title = (match.group(1) if match else "").strip()
+    return not title or title.lower() == "error"
+
+
+def parse_filter_options(html: str, fn_name: str) -> list[tuple[str, str, int]]:
+    document = lxml_html.fromstring(html)
+    ident = re.compile(rf"{re.escape(fn_name)}\(this,(-?\d+)\)")
+    seen: set[str] = set()
+    options: list[tuple[str, str, int]] = []
+    for item in document.xpath(f".//li[contains(@onclick, '{fn_name}')]"):
+        match = ident.search(item.get("onclick") or "")
+        if not match:
+            continue
+        option_id = match.group(1)
+        raw = (item.text or "").strip() or "".join(item.itertext()).strip()
+        prefix_match = OPTION_PREFIX_RE.match(raw)
+        prefix = prefix_match.group(0) if prefix_match else ""
+        name = raw[len(prefix):].strip()
+        if not name or option_id in seen:
+            continue
+        seen.add(option_id)
+        options.append((option_id, name, prefix.count("-")))
+    return options
+
+
+def parse_homepage(html: str, url: str) -> FacultyProfile:
+    document = lxml_html.fromstring(html)
+    for node in document.xpath(".//script|.//style|.//noscript"):
+        parent = node.getparent()
+        if parent is not None:
+            parent.remove(node)
+    title = ""
+    titles = document.xpath(".//title/text()")
+    if titles:
+        title = str(titles[0]).split("西安交通大学", 1)[0].strip()
+    body = document.find("body")
+    raw = body.text_content() if body is not None else document.text_content()
+    text = re.sub(r"\s+", " ", raw.replace("\xa0", " ")).strip()
+    return FacultyProfile(
+        template=(TEMPLATE_RE.search(html).group(1) if TEMPLATE_RE.search(html) else ""),
+        title_name=title,
+        fields=_parse_fields(text),
+        columns=_parse_columns(document, url),
+    )
+
+
+def group_columns(columns: list[FacultyColumn]) -> list[FacultyColumnGroup]:
+    sections = [column for column in columns if column.depth == 0]
+    children: dict[str | None, list[FacultyColumn]] = {}
+    for column in columns:
+        if column.depth > 0:
+            children.setdefault(column.parent_id, []).append(column)
+    groups = []
+    claimed: set[str] = set()
+    for section in sections:
+        kids = [child for child in children.get(section.column_id, []) if child.display_name != section.display_name]
+        claimed.update(child.column_id for child in kids)
+        groups.append(FacultyColumnGroup(section, kids))
+    for column in columns:
+        if column.depth > 0 and column.column_id not in claimed and column.parent_id is None:
+            groups.append(FacultyColumnGroup(column, []))
+    return groups
+
+
+def _parse_fields(text: str) -> dict[str, str]:
+    hits: list[tuple[int, int, str]] = []
+    for label in PROFILE_LABELS:
+        for match in re.finditer(re.escape(label) + r"\s*[：:]\s*", text):
+            hits.append((match.start(), match.end(), label))
+    if not hits:
+        return {}
+    hits.sort(key=lambda item: item[0])
+    unique: list[tuple[int, int, str]] = []
+    for hit in hits:
+        if unique and hit[0] < unique[-1][1]:
+            continue
+        unique.append(hit)
+    clusters: list[list[tuple[int, int, str]]] = []
+    for hit in unique:
+        if clusters and hit[0] - clusters[-1][-1][1] <= FIELD_CLUSTER_GAP:
+            clusters[-1].append(hit)
+        else:
+            clusters.append([hit])
+    block = max(clusters, key=_cluster_score)
+    fields: dict[str, str] = {}
+    for index, (start, value_start, label) in enumerate(block):
+        end = block[index + 1][0] if index + 1 < len(block) else min(len(text), value_start + FIELD_VALUE_MAX)
+        value = text[value_start:max(end, value_start)]
+        for stopper in (*FIELD_BLOCK_STOPPERS, *COLUMN_NAMES.values(), *SKIP_COLUMN_TITLES):
+            at = value.find(stopper)
+            if at >= 0:
+                value = value[:at]
+        value = value.strip().strip("|-·").strip()
+        if not value or len(value) > FIELD_VALUE_MAX or ENCRYPTED_VALUE_RE.match(value):
+            continue
+        fields.setdefault(label, value)
+    return fields
+
+
+def _parse_columns(document, page_url: str) -> list[FacultyColumn]:
+    site_id = page_url.removeprefix(f"{HOMEPAGE_HOST}/").split("/", 1)[0]
+    raws: list[tuple[FacultyColumn, int]] = []
+    seen: set[str] = set()
+    for anchor in document.xpath(".//a[@href]"):
+        href = anchor.get("href") or ""
+        match = COLUMN_URL_RE.search(href)
+        if not match:
+            continue
+        owner, column_type, column_id = match.groups()
+        if site_id and owner != site_id:
+            continue
+        if column_id in seen:
+            continue
+        seen.add(column_id)
+        depth = sum(1 for parent in anchor.iterancestors() if parent.tag == "ul")
+        raws.append((
+            FacultyColumn(
+                type=column_type,
+                column_id=column_id,
+                url=absolute_url(match.group(0)),
+                title=re.sub(r"\s+", " ", "".join(anchor.itertext())).strip(),
+            ),
+            depth,
+        ))
+    if not raws:
+        return []
+    base = min(depth for _, depth in raws)
+    current_section: str | None = None
+    columns: list[FacultyColumn] = []
+    for column, depth in raws:
+        normalized = min(max(depth - base, 0), 1)
+        if normalized == 0:
+            current_section = column.column_id
+            column.depth = 0
+            column.parent_id = None
+        else:
+            column.depth = 1
+            column.parent_id = current_section
+        columns.append(column)
+    return _clean_columns(columns)
+
+
+def _cluster_score(cluster: list[tuple[int, int, str]]) -> int:
+    labels = {item[2] for item in cluster}
+    score = len(cluster)
+    if "职称" in labels or "所在单位" in labels:
+        score += 8
+    if "学科" in labels or "学历" in labels:
+        score += 3
+    return score
+
+
+def _clean_columns(columns: list[FacultyColumn]) -> list[FacultyColumn]:
+    cleaned: list[FacultyColumn] = []
+    seen: set[tuple[str, str]] = set()
+    for column in columns:
+        if column.type == "index":
+            continue
+        name = column.display_name.strip()
+        if not name or name in SKIP_COLUMN_TITLES or len(name) > 16 or looks_mojibake(name):
+            continue
+        key = (column.type, name)
+        if key in seen:
+            continue
+        seen.add(key)
+        cleaned.append(column)
+    return cleaned
+
+
+def extra_fields(fields: dict[str, str], known_labels: set[str], known_values: set[str]) -> list[tuple[str, str]]:
+    """Homepage fields that are not already in the search JSON."""
+    blocked = set()
+    for label in known_labels:
+        blocked.update(_label_aliases(label))
+    seen_values = {value.strip() for value in known_values if value}
+    extras: list[tuple[str, str]] = []
+    for label, value in fields.items():
+        cleaned = value.strip()
+        if not cleaned or cleaned in seen_values or looks_mojibake(cleaned):
+            continue
+        if _label_aliases(label) & blocked:
+            continue
+        extras.append((label, cleaned))
+        seen_values.add(cleaned)
+        blocked.update(_label_aliases(label))
+    return extras
+
+
+def _label_aliases(label: str) -> set[str]:
+    names = {label}
+    names.update(FIELD_ALIASES.get(label, set()))
+    for key, group in FIELD_ALIASES.items():
+        if label == key or label in group:
+            names.add(key)
+            names.update(group)
+    return names

--- a/faculty/search.py
+++ b/faculty/search.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import requests
+
+from auth import ServerError
+from .homepage import (
+    FACULTY_HOST,
+    HomepageResult,
+    absolute_url,
+    decode_page,
+    is_standard_homepage,
+    is_unavailable_page,
+    looks_like_json,
+    parse_filter_options,
+    parse_homepage,
+)
+
+
+@dataclass
+class FacultyFilter:
+    colleges: list[tuple[str, str]] = field(default_factory=list)
+    disciplines: list[tuple[str, str]] = field(default_factory=list)
+
+
+@dataclass
+class FacultyMember:
+    teacher_id: str
+    name: str
+    english_name: str = ""
+    college: str = ""
+    rank: str = ""
+    job: str = ""
+    discipline: str = ""
+    degree: str = ""
+    education: str = ""
+    graduated: str = ""
+    url: str = ""
+    email: str = ""
+    contact: str = ""
+    phone: str = ""
+    mobile: str = ""
+    office: str = ""
+    address: str = ""
+    entry_time: str = ""
+    profile: str = ""
+    research_list: list[str] = field(default_factory=list)
+    doctoral_tutor: bool = False
+    master_tutor: bool = False
+    pic_url: str = ""
+
+    @property
+    def research(self) -> str:
+        return "、".join(item for item in self.research_list if item)
+
+    @property
+    def tutor_label(self) -> str:
+        bits = []
+        if self.doctoral_tutor:
+            bits.append("博导")
+        if self.master_tutor:
+            bits.append("硕导")
+        return " · ".join(bits)
+
+    @property
+    def has_standard_homepage(self) -> bool:
+        return is_standard_homepage(self.url)
+
+    def basics(self) -> list[tuple[str, str]]:
+        phone = " / ".join(part for part in (self.phone, self.mobile) if part)
+        rows = (
+            ("学科", self.discipline),
+            ("学位", self.degree),
+            ("学历", self.education),
+            ("毕业院校", self.graduated),
+            ("职务", self.job),
+            ("办公地点", self.office),
+            ("邮箱", self.email),
+            ("联系方式", self.contact),
+            ("电话", phone),
+            ("通讯地址", self.address),
+            ("入职时间", self.entry_time),
+        )
+        return [(label, value) for label, value in rows if value]
+
+
+class Faculty:
+    SEARCH_PAGE = f"{FACULTY_HOST}/search.jsp?urltype=tree.TreeTempUrl&wbtreeid=1041"
+    SEARCH_API = f"{FACULTY_HOST}/system/resource/tsites/advancesearch.jsp"
+    UA = (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
+    )
+
+    def __init__(self, session: requests.Session | None = None):
+        self.session = session or requests.Session()
+
+    def _headers(self, referer: str) -> dict[str, str]:
+        return {
+            "User-Agent": self.UA,
+            "Accept-Language": "zh-CN,zh;q=0.9,en;q=0.6",
+            "Referer": referer,
+        }
+
+    def load_filters(self) -> FacultyFilter:
+        response = self.session.get(
+            self.SEARCH_PAGE,
+            headers=self._headers(f"{FACULTY_HOST}/index.jsp"),
+            timeout=20,
+        )
+        response.raise_for_status()
+        colleges = parse_filter_options(response.text, "selectByCollege")
+        disciplines = parse_filter_options(response.text, "selectByDiscipline")
+        return FacultyFilter(
+            colleges=[(option_id, name) for option_id, name, _depth in colleges if option_id != "0"],
+            disciplines=[(option_id, name) for option_id, name, _depth in disciplines if option_id != "0"],
+        )
+
+    def search(
+            self,
+            teacher_name: str = "",
+            college_id: str = "0",
+            discipline_id: str = "0",
+            page: int = 1,
+            page_size: int = 20) -> tuple[int, list[FacultyMember]]:
+        response = self.session.get(
+            self.SEARCH_API,
+            params={
+                "pageindex": page,
+                "pagesize": min(page_size, 100),
+                "profilelen": 400,
+                "collegeid": college_id or "0",
+                "disciplineid": discipline_id or "0",
+                "enrollid": "0",
+                "honorid": "0",
+                "teacherName": teacher_name,
+                "searchDirection": "",
+                "py": "",
+                "rankid": "0",
+                "degreeid": "0",
+                "tutorType": "",
+                "viewmode": "8",
+                "viewid": "1095235",
+                "siteOwner": "2105667170",
+                "viewUniqueId": "1095235",
+                "showlang": "zh_CN",
+                "ispreview": "false",
+                "basenum": "0",
+                "productType": "0",
+                "ellipsis": "...",
+                "alignright": "false",
+            },
+            headers=self._headers(self.SEARCH_PAGE),
+            timeout=20,
+        )
+        if not looks_like_json(response.text):
+            raise ServerError(1, "教师检索接口返回异常（非 JSON 响应）")
+        try:
+            payload = response.json()
+        except ValueError as exc:
+            raise ServerError(1, "教师主页接口返回了无法解析的数据") from exc
+        members = [_parse_member(item) for item in payload.get("teacherData") or []]
+        return int(payload.get("totalnum") or len(members)), members
+
+    def fetch_homepage(self, url: str) -> HomepageResult:
+        if not url:
+            return HomepageResult.not_standard(url)
+        if not is_standard_homepage(url):
+            return HomepageResult.not_standard(url)
+        try:
+            response = self.session.get(
+                url,
+                headers=self._headers(self.SEARCH_PAGE),
+                timeout=20,
+            )
+            html = decode_page(response.content)
+        except requests.RequestException as exc:
+            return HomepageResult.error(str(exc) or "主页加载失败")
+        if is_unavailable_page(html):
+            return HomepageResult.unavailable()
+        try:
+            return HomepageResult.success(parse_homepage(html, url), url)
+        except Exception as exc:
+            return HomepageResult.error(str(exc) or "主页解析失败")
+
+
+def _parse_member(item: dict) -> FacultyMember:
+    directions = item.get("researchDirectionList") or []
+    research = [
+        str(one.get("researchDirectionTitle") or "").strip()
+        for one in directions if one
+    ]
+    return FacultyMember(
+        teacher_id=str(item.get("teacherId") or ""),
+        name=str(item.get("name") or ""),
+        english_name=str(item.get("ename") or "").strip(),
+        college=str(item.get("collegeName") or item.get("unit") or "").strip(),
+        rank=str(item.get("prorank") or "").strip(),
+        job=str(item.get("job") or "").strip(),
+        discipline=str(item.get("discipline") or "").strip(),
+        degree=str(item.get("degree") or "").strip(),
+        education=str(item.get("education") or "").strip(),
+        graduated=str(item.get("graduatedUniversity") or "").strip(),
+        url=str(item.get("url") or "").strip(),
+        email=str(item.get("email") or "").strip(),
+        contact=str(item.get("contact") or "").strip(),
+        phone=str(item.get("phone") or "").strip(),
+        mobile=str(item.get("mobilephone") or "").strip(),
+        office=str(item.get("officeLocation") or "").strip(),
+        address=str(item.get("address") or "").strip(),
+        entry_time=str(item.get("entryTime") or "").strip(),
+        profile=str(item.get("profile") or item.get("profileSummary") or "").strip(),
+        research_list=[item for item in research if item],
+        doctoral_tutor=item.get("doctorTutor") == 1,
+        master_tutor=item.get("gtutor") == 1,
+        pic_url=absolute_url(str(item.get("picUrl") or "").strip(), FACULTY_HOST),
+    )


### PR DESCRIPTION
## Summary
- 工具箱增加教师主页：姓名 / 学院检索，点选后轻解析个人主页字段与栏目。
- 检索走 `faculty.xjtu.edu.cn` JSON；主页 HTML 按标签补字段，栏目名用站点栏目表。
- `gr.xjtu.edu.cn` 常不带 charset，按 UTF-8 解码，避免自定义栏目标题乱码。

## Test plan
- [x] 按姓名搜到教师，点选后 JSON 字段正常
- [x] 标准主页能解析出补充字段或栏目链接
- [x] 自定义栏目中文正常，不是 Latin-1 乱码
- [x] 可在浏览器打开个人主页
