### PR TITLE
feat: 教材全文检索与阅读

### DIFF
--- a/app/HomeInterface.py
+++ b/app/HomeInterface.py
@@ -198,6 +198,13 @@ class HomeFrame(QWidget):
                 'content': self.tr("查看作业、课件与课程回放"),
                 'callback': lambda: self.main_window.switchTo(self.main_window.lms_interface),
                 'color': LinkCard.LinkCardColor.SKY_BLUE
+            },
+            "textbook": {
+                'icon': FIF.BOOK_SHELF.icon(theme=Theme.DARK),
+                'title': self.tr("教材全文"),
+                'content': self.tr("检索教材并阅读全文"),
+                'callback': lambda: self.main_window.switchTo(self.main_window.textbook_interface),
+                'color': LinkCard.LinkCardColor.ORANGE
             }
         }
 

--- a/app/TextbookInterface.py
+++ b/app/TextbookInterface.py
@@ -1,0 +1,611 @@
+from PyQt5.QtCore import QEvent, QPoint, Qt, pyqtSignal
+from PyQt5.QtGui import QColor, QKeyEvent, QMouseEvent, QPainter, QPixmap, QWheelEvent
+from PyQt5.QtWidgets import QFrame, QHBoxLayout, QLabel, QSizePolicy, QStackedWidget, QTableWidgetItem, QVBoxLayout, QWidget
+from qfluentwidgets import (
+    BodyLabel, ComboBox, LineEdit, PrimaryPushButton, PushButton, ScrollArea, Slider, SpinBox,
+)
+
+from jiaocai import Jiaocai1Reader, JiaocaiCatalog, section_starts
+from .components.CampusPage import CampusPage
+
+
+class TextbookPageView(ScrollArea):
+    """Page canvas that can overflow, pan by drag, and show one or two pages."""
+
+    pageTurnRequested = pyqtSignal(int)
+    zoomDeltaRequested = pyqtSignal(int)
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWidgetResizable(False)
+        self.setAlignment(Qt.AlignCenter)
+        self.setFocusPolicy(Qt.StrongFocus)
+        self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        self.setHorizontalScrollBarPolicy(Qt.ScrollBarAsNeeded)
+        self.setVerticalScrollBarPolicy(Qt.ScrollBarAsNeeded)
+        self._source = QPixmap()
+        self._mode = "page"
+        self._scale = 1.0
+        self._dragging = False
+        self._moved = False
+        self._drag_start = QPoint()
+        self._scroll_start = QPoint()
+        self.image = QLabel(self)
+        self.image.setAlignment(Qt.AlignCenter)
+        self.image.setText(self.tr("打开一本教材后在这里阅读"))
+        self.image.setCursor(Qt.OpenHandCursor)
+        self.setWidget(self.image)
+        self.image.installEventFilter(self)
+        self.viewport().installEventFilter(self)
+
+    def set_placeholder(self, text: str) -> None:
+        self._source = QPixmap()
+        self.image.setPixmap(QPixmap())
+        self.image.setText(text)
+        self.image.adjustSize()
+
+    def set_pages(self, images: list[bytes]) -> bool:
+        pixmaps = []
+        for data in images:
+            pixmap = QPixmap()
+            if data and pixmap.loadFromData(data):
+                pixmaps.append(pixmap)
+        if not pixmaps:
+            self.set_placeholder(self.tr("本页没有图像"))
+            return False
+        self._source = pixmaps[0] if len(pixmaps) == 1 else self._compose(pixmaps)
+        self._render()
+        return True
+
+    def set_image(self, image: bytes) -> bool:
+        return self.set_pages([image])
+
+    def set_mode(self, mode: str) -> None:
+        self._mode = mode
+        if mode != "zoom":
+            self._scale = 1.0
+        self._render()
+
+    def set_fit_width(self, enabled: bool = True) -> None:
+        self.set_mode("width" if enabled else "page")
+
+    def set_fit_page(self) -> None:
+        self.set_mode("page")
+
+    def adjust_zoom(self, steps: int) -> None:
+        if self._source.isNull():
+            return
+        current = self._current_scale()
+        self._mode = "zoom"
+        self._scale = min(4.0, max(0.2, current * (1.2 ** steps)))
+        self._render()
+
+    def scale_percent(self) -> int:
+        return int(round(self._current_scale() * 100))
+
+    def mode_label(self) -> str:
+        if self._mode == "page":
+            return self.tr("适合页面")
+        if self._mode == "width":
+            return self.tr("适合宽度")
+        return f"{self.scale_percent()}%"
+
+    def resizeEvent(self, event):
+        super().resizeEvent(event)
+        if self._mode != "zoom" and not self._source.isNull():
+            self._render()
+
+    def eventFilter(self, watched, event):
+        if event.type() == QEvent.Wheel and isinstance(event, QWheelEvent):
+            if event.modifiers() & Qt.ControlModifier:
+                self.zoomDeltaRequested.emit(1 if event.angleDelta().y() > 0 else -1)
+                return True
+            if self._mode == "page" and not self._overflows():
+                self.pageTurnRequested.emit(-1 if event.angleDelta().y() > 0 else 1)
+                return True
+        if event.type() == QEvent.MouseButtonPress and isinstance(event, QMouseEvent):
+            if event.button() == Qt.LeftButton:
+                self._dragging = True
+                self._moved = False
+                self._drag_start = event.globalPos()
+                self._scroll_start = QPoint(self.horizontalScrollBar().value(), self.verticalScrollBar().value())
+                self.image.setCursor(Qt.ClosedHandCursor)
+                return True
+        if event.type() == QEvent.MouseMove and isinstance(event, QMouseEvent) and self._dragging:
+            delta = event.globalPos() - self._drag_start
+            if abs(delta.x()) > 4 or abs(delta.y()) > 4:
+                self._moved = True
+            self.horizontalScrollBar().setValue(self._scroll_start.x() - delta.x())
+            self.verticalScrollBar().setValue(self._scroll_start.y() - delta.y())
+            return True
+        if event.type() == QEvent.MouseButtonRelease and isinstance(event, QMouseEvent):
+            if event.button() == Qt.LeftButton and self._dragging:
+                self._dragging = False
+                self.image.setCursor(Qt.OpenHandCursor)
+                if not self._moved:
+                    width = max(1, self.viewport().width())
+                    local = self.viewport().mapFromGlobal(event.globalPos())
+                    ratio = local.x() / width
+                    if ratio < 0.28:
+                        self.pageTurnRequested.emit(-1)
+                    elif ratio > 0.72:
+                        self.pageTurnRequested.emit(1)
+                return True
+        return super().eventFilter(watched, event)
+
+    def _compose(self, pages: list[QPixmap]) -> QPixmap:
+        gap = 12
+        width = sum(page.width() for page in pages) + gap * (len(pages) - 1)
+        height = max(page.height() for page in pages)
+        canvas = QPixmap(width, height)
+        canvas.fill(QColor("#f4f1ea"))
+        painter = QPainter(canvas)
+        x = 0
+        for page in pages:
+            painter.drawPixmap(x, (height - page.height()) // 2, page)
+            x += page.width() + gap
+        painter.end()
+        return canvas
+
+    def _current_scale(self) -> float:
+        if self._source.isNull():
+            return 1.0
+        view_w = max(1, self.viewport().width() - 16)
+        view_h = max(1, self.viewport().height() - 16)
+        page_w = max(1, self._source.width())
+        page_h = max(1, self._source.height())
+        if self._mode == "page":
+            return min(view_w / page_w, view_h / page_h)
+        if self._mode == "width":
+            return view_w / page_w
+        return self._scale
+
+    def _overflows(self) -> bool:
+        pixmap = self.image.pixmap()
+        if pixmap is None or pixmap.isNull():
+            return False
+        return pixmap.width() > self.viewport().width() or pixmap.height() > self.viewport().height()
+
+    def _render(self) -> None:
+        if self._source.isNull():
+            return
+        scale = self._current_scale()
+        width = max(1, int(self._source.width() * scale))
+        height = max(1, int(self._source.height() * scale))
+        scaled = self._source.scaled(width, height, Qt.KeepAspectRatio, Qt.SmoothTransformation)
+        self.image.setText("")
+        self.image.setPixmap(scaled)
+        self.image.resize(scaled.size())
+        self.image.setCursor(Qt.OpenHandCursor)
+
+
+class TextbookInterface(CampusPage):
+    def __init__(self, parent=None):
+        super().__init__("textbookInterface", "教材全文", "检索教材，按页阅读全文", parent)
+        self.catalog_books = []
+        self.reader_books = []
+        self.handle = None
+        self.page_index = 0
+        self._spread = True
+        self._cache: dict[int, bytes] = {}
+        self._resume: dict[str, int] = {}
+        self._prefetching = False
+
+        self.stack = QStackedWidget(self.view)
+        self.stack.addWidget(self._build_search_page())
+        self.stack.addWidget(self._build_reader_page())
+        self.vBoxLayout.addWidget(self.stack, 1)
+        self.stack.currentChanged.connect(self._on_stack_changed)
+
+    def _build_search_page(self) -> QWidget:
+        page = QWidget(self.stack)
+        layout = QVBoxLayout(page)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(10)
+
+        self.modeBox = ComboBox(page)
+        self.modeBox.addItems([self.tr("教材目录"), self.tr("全文库")])
+        self.keywordEdit = LineEdit(page)
+        self.keywordEdit.setPlaceholderText(self.tr("书名 / 课程 / 作者"))
+        self.keywordEdit.setMinimumWidth(240)
+        self.keywordEdit.returnPressed.connect(self.search)
+        self.searchButton = PrimaryPushButton(self.tr("搜索"), page)
+        self.openButton = PrimaryPushButton(self.tr("打开全文"), page)
+        self.searchButton.clicked.connect(self.search)
+        self.openButton.clicked.connect(self.open_selected)
+
+        bar = QFrame(page)
+        bar_layout = QHBoxLayout(bar)
+        bar_layout.setContentsMargins(0, 0, 0, 0)
+        bar_layout.setSpacing(8)
+        bar_layout.addWidget(self.labeled(self.tr("来源"), self.modeBox, width=40))
+        bar_layout.addWidget(self.keywordEdit, 1)
+        bar_layout.addWidget(self.searchButton)
+        bar_layout.addWidget(self.openButton)
+        layout.addWidget(bar)
+
+        self.hint = BodyLabel(self.tr("双击打开阅读器。支持双页、拖拽平移、适合页面；Ctrl+滚轮缩放。"), page)
+        self.hint.setWordWrap(True)
+        layout.addWidget(self.hint)
+
+        self.table = self.make_table([self.tr("书名"), self.tr("作者"), self.tr("摘要 / 出版")])
+        self.table.doubleClicked.connect(self.open_selected)
+        layout.addWidget(self.table, 1)
+        return page
+
+    def _build_reader_page(self) -> QWidget:
+        page = QWidget(self.stack)
+        page.setFocusPolicy(Qt.StrongFocus)
+        layout = QVBoxLayout(page)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(8)
+
+        self.backButton = PushButton(self.tr("返回列表"), page)
+        self.sectionBox = ComboBox(page)
+        self.sectionBox.setMinimumWidth(120)
+        self.prevButton = PushButton(self.tr("上一页"), page)
+        self.nextButton = PushButton(self.tr("下一页"), page)
+        self.pageSpin = SpinBox(page)
+        self.pageSpin.setMinimumWidth(90)
+        self.spreadButton = PushButton(self.tr("双页"), page)
+        self.spreadButton.setCheckable(True)
+        self.spreadButton.setChecked(True)
+        self.fitPageButton = PushButton(self.tr("适合页面"), page)
+        self.fitWidthButton = PushButton(self.tr("适合宽度"), page)
+        self.zoomOutButton = PushButton(self.tr("缩小"), page)
+        self.zoomInButton = PushButton(self.tr("放大"), page)
+        self.backButton.clicked.connect(self.back_to_list)
+        self.sectionBox.currentIndexChanged.connect(self._on_section)
+        self.prevButton.clicked.connect(lambda: self.turn_page(-1))
+        self.nextButton.clicked.connect(lambda: self.turn_page(1))
+        self.pageSpin.valueChanged.connect(self._on_spin)
+        self.spreadButton.toggled.connect(self._on_spread)
+        self.fitPageButton.clicked.connect(self._fit_page)
+        self.fitWidthButton.clicked.connect(self._fit_width)
+        self.zoomOutButton.clicked.connect(lambda: self._zoom(-1))
+        self.zoomInButton.clicked.connect(lambda: self._zoom(1))
+
+        top = QFrame(page)
+        top_layout = QHBoxLayout(top)
+        top_layout.setContentsMargins(0, 0, 0, 0)
+        top_layout.setSpacing(8)
+        for widget in (
+            self.backButton, self.sectionBox, self.prevButton, self.pageSpin,
+            self.nextButton, self.spreadButton, self.fitPageButton, self.fitWidthButton,
+            self.zoomOutButton, self.zoomInButton,
+        ):
+            top_layout.addWidget(widget)
+        top_layout.addStretch(1)
+        layout.addWidget(top)
+
+        self.pageSlider = Slider(page)
+        self.pageSlider.setOrientation(Qt.Horizontal)
+        self.pageSlider.setMinimumHeight(28)
+        self.pageSlider.sliderReleased.connect(self._on_slider)
+        layout.addWidget(self.pageSlider)
+
+        self.statusLabel = BodyLabel(self.tr("尚未打开"), page)
+        self.statusLabel.setWordWrap(True)
+        layout.addWidget(self.statusLabel)
+
+        self.pageView = TextbookPageView(page)
+        self.pageView.setMinimumHeight(420)
+        self.pageView.pageTurnRequested.connect(self.turn_page)
+        self.pageView.zoomDeltaRequested.connect(self._zoom)
+        layout.addWidget(self.pageView, 1)
+        page.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        page.installEventFilter(self)
+        return page
+
+    def eventFilter(self, watched, event):
+        if isinstance(event, QKeyEvent) and event.type() == QEvent.KeyPress and self.stack.currentIndex() == 1:
+            if self._handle_reader_key(event.key()):
+                return True
+        return super().eventFilter(watched, event)
+
+    def keyPressEvent(self, event: QKeyEvent):
+        if self.stack.currentIndex() == 1 and self._handle_reader_key(event.key()):
+            return
+        if self.stack.currentIndex() == 0 and event.key() in (Qt.Key_Return, Qt.Key_Enter):
+            if self.table.hasFocus() or self.table.currentRow() >= 0:
+                self.open_selected()
+                return
+        super().keyPressEvent(event)
+
+    def _handle_reader_key(self, key: int) -> bool:
+        if key in (Qt.Key_Left, Qt.Key_PageUp):
+            self.turn_page(-1)
+            return True
+        if key in (Qt.Key_Right, Qt.Key_PageDown, Qt.Key_Space):
+            self.turn_page(1)
+            return True
+        if key == Qt.Key_Home:
+            self._goto(0)
+            return True
+        if key == Qt.Key_End and self.handle:
+            self._goto(len(self.handle.pages) - 1)
+            return True
+        if key in (Qt.Key_Minus, Qt.Key_Underscore):
+            self._zoom(-1)
+            return True
+        if key in (Qt.Key_Plus, Qt.Key_Equal):
+            self._zoom(1)
+            return True
+        if key == Qt.Key_0:
+            self._fit_page()
+            return True
+        if key == Qt.Key_D:
+            self.spreadButton.toggle()
+            return True
+        if key == Qt.Key_Escape:
+            self.back_to_list()
+            return True
+        return False
+
+    def search(self):
+        if not self.require_account():
+            return
+        keyword = self.keywordEdit.text().strip()
+        if not keyword:
+            self.warn(self.tr("请输入关键词"), self.tr("教材检索需要书名或课程名"))
+            return
+        if self.modeBox.currentIndex() == 0:
+            self.start_job("jiaocai", self.tr("正在搜索教材..."), lambda session: JiaocaiCatalog(session).search(keyword), self._on_catalog)
+        else:
+            self.start_job("jiaocai", self.tr("正在搜索全文库..."), lambda session: Jiaocai1Reader(session).search(keyword), self._on_reader_search)
+
+    def _on_catalog(self, books):
+        self.catalog_books = books
+        self.reader_books = []
+        self.stack.setCurrentIndex(0)
+        self.table.setRowCount(len(books))
+        for row, book in enumerate(books):
+            self.table.setItem(row, 0, QTableWidgetItem(book.title))
+            self.table.setItem(row, 1, QTableWidgetItem(book.author))
+            extra = book.summary[:80] if book.summary else (self.tr("可打开全文") if book.ssno else self.tr("打开后尝试取全文编号"))
+            self.table.setItem(row, 2, QTableWidgetItem(extra))
+        self.table.resizeRowsToContents()
+        self.success(self.tr("查询成功"), self.tr("共 {count} 本").format(count=len(books)))
+
+    def _on_reader_search(self, result):
+        self.reader_books = result.books
+        self.catalog_books = []
+        self.stack.setCurrentIndex(0)
+        self.table.setRowCount(len(result.books))
+        for row, book in enumerate(result.books):
+            self.table.setItem(row, 0, QTableWidgetItem(book.title))
+            self.table.setItem(row, 1, QTableWidgetItem(book.author))
+            extra = "  ·  ".join(part for part in (book.publish_date, book.theme) if part)
+            self.table.setItem(row, 2, QTableWidgetItem(extra))
+        self.table.resizeRowsToContents()
+        self.success(self.tr("查询成功"), self.tr("共 {count} 本").format(count=result.total_rows))
+
+    def open_selected(self):
+        if not self.require_account():
+            return
+        row = self.table.currentRow()
+        if row < 0:
+            self.warn(self.tr("未选择"), self.tr("请先选择一本教材"))
+            return
+        if self.catalog_books:
+            if row >= len(self.catalog_books):
+                return
+            book = self.catalog_books[row]
+
+            def worker(session):
+                ssno = JiaocaiCatalog(session).fetch_ssno(book)
+                if not ssno:
+                    raise RuntimeError("该书没有全文库编号")
+                return self._open_handle(session, ssno)
+        else:
+            if row >= len(self.reader_books):
+                return
+            book = self.reader_books[row]
+
+            def worker(session):
+                return self._open_handle(session, book.ssno)
+
+        self.start_job("jiaocai", self.tr("正在打开全文..."), worker, self._on_opened)
+
+    def _open_handle(self, session, ssno: str):
+        handle = Jiaocai1Reader(session).open_book(ssno)
+        if handle is None or not handle.pages:
+            raise RuntimeError("打开全文失败")
+        index = min(self._resume.get(ssno, 0), len(handle.pages) - 1)
+        images = self._fetch_indexes(session, handle, self._needed_indexes(handle, index, spread=True))
+        return handle, index, images
+
+    def _on_opened(self, payload):
+        handle, index, images = payload
+        self.handle = handle
+        self.page_index = index
+        self._cache = dict(images)
+        self._fill_sections()
+        self._sync_pager()
+        self.pageView.set_fit_page()
+        self.stack.setCurrentIndex(1)
+        self._show_current()
+        self._prefetch()
+
+    def back_to_list(self):
+        if self.handle:
+            self._resume[self.handle.ssno] = self.page_index
+        self.stack.setCurrentIndex(0)
+
+    def turn_page(self, delta: int):
+        if not self.handle:
+            return
+        step = 2 if self._spread else 1
+        self._goto(self.page_index + delta * step)
+
+    def _needed_indexes(self, handle=None, index: int | None = None, spread: bool | None = None) -> list[int]:
+        book = handle or self.handle
+        if book is None or not book.pages:
+            return []
+        current = self.page_index if index is None else index
+        current = max(0, min(len(book.pages) - 1, current))
+        use_spread = self._spread if spread is None else spread
+        if use_spread and current + 1 < len(book.pages):
+            return [current, current + 1]
+        return [current]
+
+    def _fetch_indexes(self, session, handle, indexes: list[int]) -> dict[int, bytes]:
+        reader = Jiaocai1Reader(session)
+        return {index: reader.fetch_page(handle, handle.pages[index]) for index in indexes}
+
+    def _goto(self, index: int):
+        if not self.handle or not self.handle.pages:
+            return
+        nxt = max(0, min(len(self.handle.pages) - 1, index))
+        needed = self._needed_indexes(index=nxt)
+        missing = [item for item in needed if item not in self._cache]
+        if not missing:
+            self.page_index = nxt
+            self._resume[self.handle.ssno] = nxt
+            self._sync_pager()
+            self._show_current()
+            self._prefetch()
+            return
+        handle = self.handle
+        self.start_job(
+            "jiaocai",
+            self.tr("正在加载书页..."),
+            lambda session, book=handle, target=nxt, wait=missing: (target, self._fetch_indexes(session, book, wait)),
+            self._on_page,
+        )
+
+    def _on_page(self, payload):
+        index, images = payload
+        if not self.handle:
+            return
+        self.page_index = index
+        self._resume[self.handle.ssno] = index
+        self._cache.update(images)
+        self._sync_pager()
+        self._show_current()
+        self._prefetch()
+
+    def _prefetch(self):
+        if not self.handle:
+            return
+        nearby = [self.page_index - 2, self.page_index - 1, self.page_index + 1, self.page_index + 2]
+        if self._spread:
+            nearby.extend((self.page_index + 3, self.page_index + 4))
+        missing = [
+            index for index in nearby
+            if 0 <= index < len(self.handle.pages) and index not in self._cache
+        ]
+        if not missing or (self.thread is not None and self.thread.isRunning()):
+            return
+        handle = self.handle
+        self._prefetching = True
+        self.start_job(
+            "jiaocai",
+            self.tr("正在预取相邻页..."),
+            lambda session, book=handle, wait=missing: (book.ssno, self._fetch_indexes(session, book, wait)),
+            self._on_prefetch,
+            show_process=False,
+        )
+
+    def _on_prefetch(self, payload):
+        self._prefetching = False
+        ssno, images = payload
+        if self.handle and self.handle.ssno == ssno and isinstance(images, dict):
+            self._cache.update(images)
+
+    def _show_current(self):
+        if not self.handle:
+            return
+        needed = self._needed_indexes()
+        images = [self._cache[index] for index in needed if index in self._cache]
+        ok = bool(images) and self.pageView.set_pages(images)
+        self._update_status(ok)
+
+    def _update_status(self, ok: bool = True) -> None:
+        if not self.handle or not self.handle.pages:
+            self.statusLabel.setText(self.tr("尚未打开"))
+            return
+        needed = self._needed_indexes()
+        labels = " – ".join(self.handle.pages[index].label for index in needed)
+        if len(needed) == 1:
+            current = str(needed[0] + 1)
+        else:
+            current = f"{needed[0] + 1}-{needed[-1] + 1}"
+        mode = self.tr("双页") if len(needed) > 1 else self.tr("单页")
+        suffix = "" if ok else self.tr("（本页图像缺失）")
+        self.statusLabel.setText(
+            self.tr("{title}  ·  {label}  ·  {current}/{total}  ·  {mode}  ·  {zoom}{suffix}").format(
+                title=self.handle.title or self.tr("教材全文"),
+                label=labels,
+                current=current,
+                total=len(self.handle.pages),
+                mode=mode,
+                zoom=self.pageView.mode_label(),
+                suffix=suffix,
+            )
+        )
+        self.prevButton.setEnabled(self.page_index > 0)
+        last_left = len(self.handle.pages) - (2 if self._spread and len(self.handle.pages) > 1 else 1)
+        self.nextButton.setEnabled(self.page_index < max(0, last_left))
+
+    def _fill_sections(self):
+        self.sectionBox.blockSignals(True)
+        self.sectionBox.clear()
+        if self.handle:
+            for name, index in section_starts(self.handle.pages):
+                self.sectionBox.addItem(name, userData=index)
+        self.sectionBox.blockSignals(False)
+
+    def _sync_pager(self):
+        total = len(self.handle.pages) if self.handle else 1
+        self.pageSpin.blockSignals(True)
+        self.pageSlider.blockSignals(True)
+        self.pageSpin.setRange(1, max(1, total))
+        self.pageSpin.setValue(self.page_index + 1)
+        self.pageSlider.setRange(0, max(0, total - 1))
+        self.pageSlider.setValue(self.page_index)
+        self.pageSlider.setEnabled(total > 1)
+        self.pageSpin.blockSignals(False)
+        self.pageSlider.blockSignals(False)
+        if self.handle:
+            current_type = self.handle.pages[self.page_index].type_index
+            self.sectionBox.blockSignals(True)
+            for i in range(self.sectionBox.count()):
+                start = self.sectionBox.itemData(i)
+                if 0 <= start < len(self.handle.pages) and self.handle.pages[start].type_index == current_type:
+                    self.sectionBox.setCurrentIndex(i)
+                    break
+            self.sectionBox.blockSignals(False)
+
+    def _on_section(self, _index: int):
+        start = self.sectionBox.currentData()
+        if start is not None:
+            self._goto(int(start))
+
+    def _on_spin(self, value: int):
+        self._goto(value - 1)
+
+    def _on_slider(self):
+        self._goto(self.pageSlider.value())
+
+    def _on_spread(self, checked: bool):
+        self._spread = checked
+        if self.handle:
+            self._goto(self.page_index)
+
+    def _fit_page(self):
+        self.pageView.set_fit_page()
+        self._update_status()
+
+    def _fit_width(self):
+        self.pageView.set_fit_width(True)
+        self._update_status()
+
+    def _zoom(self, steps: int):
+        self.pageView.adjust_zoom(steps)
+        self._update_status()
+
+    def _on_stack_changed(self, index: int):
+        self.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff if index == 1 else Qt.ScrollBarAsNeeded)
+        if index == 1:
+            self.pageView.setFocus()

--- a/app/components/CampusPage.py
+++ b/app/components/CampusPage.py
@@ -1,0 +1,113 @@
+from PyQt5.QtWidgets import QFrame, QHBoxLayout, QHeaderView, QVBoxLayout, QWidget
+from qfluentwidgets import BodyLabel, InfoBar, InfoBarPosition, ScrollArea, StrongBodyLabel, TableWidget, TitleLabel
+
+from app.threads.CampusFeatureThread import CampusFeatureThread
+from app.threads.ProcessWidget import ProcessWidget
+from app.utils import StyleSheet, accounts
+
+
+class CampusPage(ScrollArea):
+    """Shared chrome for newly ported campus tools."""
+
+    def __init__(self, object_name: str, title: str, subtitle: str, parent=None):
+        super().__init__(parent)
+        self.setObjectName(object_name)
+        self.view = QWidget(self)
+        self.view.setObjectName("view")
+        self.vBoxLayout = QVBoxLayout(self.view)
+        self.vBoxLayout.setContentsMargins(24, 24, 24, 40)
+        self.vBoxLayout.setSpacing(10)
+        self.titleLabel = TitleLabel(title, self.view)
+        self.titleLabel.setContentsMargins(10, 15, 0, 0)
+        self.vBoxLayout.addWidget(self.titleLabel)
+        self.minorLabel = StrongBodyLabel(subtitle, self.view)
+        self.minorLabel.setContentsMargins(15, 5, 0, 0)
+        self.vBoxLayout.addWidget(self.minorLabel)
+
+        self.jobSlot = QWidget(self.view)
+        self.jobLayout = QVBoxLayout(self.jobSlot)
+        self.jobLayout.setContentsMargins(0, 0, 0, 0)
+        self.jobLayout.setSpacing(0)
+        self.vBoxLayout.addWidget(self.jobSlot)
+        self.thread = None
+        self.processWidget = None
+
+        StyleSheet.EMPTY_ROOM_INTERFACE.apply(self)
+        self.setWidgetResizable(True)
+        self.setWidget(self.view)
+        self._notice = None
+
+    def add_toolbar(self, *widgets) -> QFrame:
+        bar = QFrame(self.view)
+        layout = QHBoxLayout(bar)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(8)
+        for widget in widgets:
+            if widget is not None:
+                layout.addWidget(widget)
+        layout.addStretch(1)
+        self.vBoxLayout.addWidget(bar)
+        return bar
+
+    def labeled(self, text: str, widget: QWidget, width: int = 56) -> QFrame:
+        box = QFrame(self.view)
+        layout = QHBoxLayout(box)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(6)
+        label = BodyLabel(text, box)
+        label.setFixedWidth(width)
+        layout.addWidget(label)
+        layout.addWidget(widget)
+        return box
+
+    def make_table(self, headers: list[str]) -> TableWidget:
+        table = TableWidget(self.view)
+        table.setColumnCount(len(headers))
+        table.setHorizontalHeaderLabels(headers)
+        table.horizontalHeader().setSectionResizeMode(QHeaderView.ResizeToContents)
+        table.horizontalHeader().setStretchLastSection(True)
+        table.verticalHeader().setVisible(False)
+        table.setEditTriggers(TableWidget.NoEditTriggers)
+        table.setWordWrap(True)
+        table.setAlternatingRowColors(True)
+        table.setSelectionBehavior(TableWidget.SelectRows)
+        return table
+
+    def start_job(self, site_key: str, message: str, worker, on_result, need_login: bool = True,
+                  show_process: bool = True) -> bool:
+        if self.thread is not None and self.thread.isRunning():
+            self.thread.can_run = False
+        self.thread = CampusFeatureThread(site_key, message, worker, need_login=need_login, parent=self)
+        if self.processWidget:
+            self.processWidget.deleteLater()
+            self.processWidget = None
+        if show_process:
+            self.processWidget = ProcessWidget(self.thread, self.jobSlot, hide_on_end=True)
+            self.jobLayout.addWidget(self.processWidget)
+        self.thread.result.connect(on_result)
+        self.thread.error.connect(self.warn)
+        self.thread.start()
+        return True
+
+    def require_account(self) -> bool:
+        if accounts.current is None:
+            self.warn(self.tr("未登录"), self.tr("请先添加一个账户"))
+            return False
+        return True
+
+    def info(self, title: str, msg: str) -> None:
+        self._bar(InfoBar.info, title, msg)
+
+    def success(self, title: str, msg: str) -> None:
+        self._bar(InfoBar.success, title, msg)
+
+    def warn(self, title: str, msg: str) -> None:
+        self._bar(InfoBar.warning, title, msg)
+
+    def _bar(self, factory, title: str, msg: str) -> None:
+        if self._notice is not None:
+            try:
+                self._notice.close()
+            except RuntimeError:
+                self._notice = None
+        self._notice = factory(title, msg, duration=2500, position=InfoBarPosition.TOP_RIGHT, parent=self)

--- a/app/main_window.py
+++ b/app/main_window.py
@@ -32,6 +32,8 @@ from .sessions.gste_session import GSTESession
 from .sessions.jwapp_session import JwappSession
 from .sessions.lms_session import LMSSession
 from .sessions.venue_session import VenueSession
+from .sessions.jiaocai_session import JiaocaiSession
+from .TextbookInterface import TextbookInterface
 from .sub_interfaces import LoginInterface
 from .sub_interfaces.QRCodeLoginDialog import QRCodeLoginDialog
 from .sub_interfaces.VerifyCodeDialog import VerifyCodeDialog
@@ -62,6 +64,7 @@ def registerSession():
     SessionManager.global_register(GSTESession, "gste")
     SessionManager.global_register(LMSSession, "lms")
     SessionManager.global_register(VenueSession, "venue")
+    SessionManager.global_register(JiaocaiSession, "jiaocai")
 
 
 class MacReopenFilter(QObject):
@@ -201,6 +204,8 @@ class MainWindow(MSFluentWindow):
         self.lms_interface = LMSInterface(self)
         QApplication.processEvents()
         self.venue_interface = VenueInterface(self)
+        QApplication.processEvents()
+        self.textbook_interface = TextbookInterface(self)
         QApplication.processEvents()
 
         self.tray_interface = TrayInterface(QIcon("assets/icons/main_icon.ico"))
@@ -363,6 +368,12 @@ class MainWindow(MSFluentWindow):
         empty_room_card = self.tool_box_interface.addCard(self.empty_room_interface, FIF.LAYOUT, self.tr("空闲教室"),
                                                           self.tr("查询当前空闲的教室"))
         empty_room_card.setFixedSize(200, 180)
+
+        textbook_card = self.tool_box_interface.addCard(
+            self.textbook_interface, FIF.BOOK_SHELF, self.tr("教材全文"),
+            self.tr("检索教材并阅读全文"),
+        )
+        textbook_card.setFixedSize(200, 180)
 
         # 添加登录界面作为子界面，但是将其隐藏
         button = self.addSubInterface(self.login_interface, FIF.SCROLL, self.tr("登录"),

--- a/app/sessions/jiaocai_session.py
+++ b/app/sessions/jiaocai_session.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from auth import ServerError
+from auth.constant import JIAOCAI_LOGIN_URL
+from auth.new_login import NewLogin, NewWebVPNLogin
+from .common_session import CommonLoginSession
+from .session_backend import AccessMode
+from ..utils import cfg
+
+
+class JiaocaiSession(CommonLoginSession):
+    """jiaocai.lib / jiaocai1.lib 共用会话。"""
+
+    site_key = "jiaocai"
+    site_name = "教材中心"
+    supports_webvpn = True
+    use_webvpn_when_off_campus = True
+
+    USER_INFO_URL = "https://jiaocai.lib.xjtu.edu.cn/engine2/header/user-info"
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.enc = ""
+        self.uid = ""
+
+    def clear_site_state(self) -> None:
+        super().clear_site_state()
+        self.enc = ""
+        self.uid = ""
+
+    def restore_site_snapshot(self, snapshot) -> None:
+        super().restore_site_snapshot(snapshot)
+        self.enc = self.headers.get("X-Jiaocai-Enc", "")
+        self.uid = self.headers.get("X-Jiaocai-Uid", "")
+
+    def _login(self, username: str, password: str, **kwargs: object) -> None:
+        login_class = NewWebVPNLogin if self.access_mode == AccessMode.WEBVPN else NewLogin
+        self.perform_cas_login(
+            username,
+            password,
+            kwargs=kwargs,
+            password_login_factory=lambda: login_class(
+                JIAOCAI_LOGIN_URL, session=self, visitor_id=str(cfg.loginId.value)
+            ),
+            qrcode_login_factory=None,
+            allow_qrcode_login=False,
+        )
+        response = self.get(self.USER_INFO_URL, timeout=15, _skip_auth_check=True)
+        try:
+            data = (response.json() or {}).get("data") or {}
+        except ValueError:
+            data = {}
+        self.uid = str(data.get("uid") or "")
+        self.enc = str(data.get("enc") or "")
+        if self.uid:
+            self.headers["X-Jiaocai-Uid"] = self.uid
+            self.headers["X-Jiaocai-Enc"] = self.enc
+        elif "login.xjtu.edu.cn" in response.url:
+            raise ServerError(102, "教材中心登录失败")
+        self.reset_timeout()
+        self.has_login = True
+
+    _re_login = _login
+
+    def validate_login(self) -> bool:
+        response = self.get(self.USER_INFO_URL, timeout=10, _skip_auth_check=True)
+        if not response.ok or self.is_auth_failure_response(response):
+            return False
+        try:
+            data = (response.json() or {}).get("data") or {}
+        except ValueError:
+            return False
+        return bool(data.get("uid"))

--- a/app/threads/CampusFeatureThread.py
+++ b/app/threads/CampusFeatureThread.py
@@ -1,0 +1,39 @@
+from collections.abc import Callable
+from typing import Any
+
+from PyQt5.QtCore import pyqtSignal
+
+from app.threads.ProcessWidget import ProcessThread
+from app.utils.campus_job import run_campus_job
+
+
+class CampusFeatureThread(ProcessThread):
+    """Login a campus site (optional) and run a worker on a background thread."""
+
+    result = pyqtSignal(object)
+
+    def __init__(
+            self,
+            site_key: str,
+            login_message: str,
+            worker: Callable[[Any], Any],
+            need_login: bool = True,
+            parent=None):
+        super().__init__(parent)
+        self.site_key = site_key
+        self.login_message = login_message
+        self.worker = worker
+        self.need_login = need_login
+
+    def run(self):
+        payload = run_campus_job(
+            self,
+            site_key=self.site_key,
+            login_message=self.login_message,
+            worker=self.worker,
+            need_login=self.need_login,
+        )
+        if payload is None:
+            return
+        self.result.emit(payload)
+        self.hasFinished.emit()

--- a/app/utils/campus_job.py
+++ b/app/utils/campus_job.py
@@ -1,0 +1,95 @@
+"""Shared login + error handling for campus feature worker threads."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import requests
+
+from auth import ServerError
+from app.threads.ProcessWidget import ProcessThread
+from app.utils import accounts, logger
+from app.utils.mfa import MFACancelledError, MFAUnavailableError
+from app.utils.qrcode_login import QRCodeLoginCancelledError, QRCodeLoginUnavailableError
+
+
+def run_campus_job(
+        thread: ProcessThread,
+        *,
+        site_key: str,
+        login_message: str,
+        worker: Callable[[Any], Any],
+        need_login: bool = True) -> Any:
+    """Login the current account into ``site_key`` (optional) and run ``worker``.
+
+    ``worker`` receives the site session (or ``None`` when ``need_login`` is false).
+    The function emits the usual ProcessThread error/cancel signals and returns
+    the worker result on success. The caller should emit ``result`` / ``hasFinished``.
+    """
+    thread.can_run = True
+    if need_login and accounts.current is None:
+        thread.error.emit(thread.tr("未登录"), thread.tr("请先添加一个账户"))
+        thread.canceled.emit()
+        return None
+
+    try:
+        session = None
+        if need_login:
+            session = accounts.current.session_manager.get_session(site_key)
+            thread.setIndeterminate.emit(True)
+            thread.messageChanged.emit(login_message)
+            session.ensure_login(
+                accounts.current.username,
+                accounts.current.password,
+                account=accounts.current,
+                mfa_provider=accounts.current.session_manager.mfa_provider,
+            )
+            if not thread.can_run:
+                thread.canceled.emit()
+                return None
+        result = worker(session)
+        if not thread.can_run:
+            thread.canceled.emit()
+            return None
+        return result
+    except QRCodeLoginCancelledError as e:
+        logger.info("二维码登录已取消：%s", e)
+        thread.error.emit(thread.tr("扫码登录已取消"), thread.tr("已取消扫码登录，本次操作未完成。"))
+        thread.canceled.emit()
+    except QRCodeLoginUnavailableError as e:
+        logger.error("二维码登录交互不可用", exc_info=True)
+        thread.error.emit(thread.tr("登录问题"), str(e))
+        thread.canceled.emit()
+    except MFACancelledError as e:
+        logger.info("MFA 验证已取消：%s", e)
+        thread.error.emit(thread.tr("安全验证已取消"), thread.tr("已取消安全验证，本次操作未完成。"))
+        thread.canceled.emit()
+    except MFAUnavailableError as e:
+        logger.error("MFA 交互不可用", exc_info=True)
+        thread.error.emit(thread.tr("登录问题"), str(e))
+        thread.canceled.emit()
+    except ServerError as e:
+        logger.error("服务器错误", exc_info=True)
+        if e.code == 102:
+            thread.error.emit(
+                thread.tr("登录问题"),
+                thread.tr("需要进行两步验证，请前往账户界面，选择对应账户进行验证。"),
+            )
+            accounts.current.MFASignal.emit(True)
+        else:
+            thread.error.emit(thread.tr("服务器错误"), e.message)
+        thread.canceled.emit()
+    except requests.ConnectionError:
+        logger.error("网络错误", exc_info=True)
+        thread.error.emit(thread.tr("无网络连接"), thread.tr("请检查网络连接，然后重试。"))
+        thread.canceled.emit()
+    except requests.RequestException as e:
+        logger.error("网络错误", exc_info=True)
+        thread.error.emit(thread.tr("网络错误"), str(e))
+        thread.canceled.emit()
+    except Exception as e:
+        logger.error("其他错误", exc_info=True)
+        thread.error.emit(thread.tr("其他错误"), str(e))
+        thread.canceled.emit()
+    return None

--- a/auth/constant.py
+++ b/auth/constant.py
@@ -31,3 +31,6 @@ YWTB_LOGIN_URL = "https://login.xjtu.edu.cn/cas/login?service=https%3A%2F%2Fywtb
 GMIS_LOGIN_URL = "https://org.xjtu.edu.cn/openplatform/oauth/authorize?appId=1036&state=abcd1234&redirectUri=http://gmis.xjtu.edu.cn/pyxx/sso/login&responseType=code&scope=user_info"
 # 研究生评教系统的登录地址
 GSTE_LOGIN_URL = "https://cas.xjtu.edu.cn/login?TARGET=http%3A%2F%2Fgste.xjtu.edu.cn%2Flogin.do"
+
+# 教材中心
+JIAOCAI_LOGIN_URL = "https://jiaocai.lib.xjtu.edu.cn/entry/login"

--- a/jiaocai/__init__.py
+++ b/jiaocai/__init__.py
@@ -1,0 +1,20 @@
+from .catalog import JiaocaiBook, JiaocaiCatalog
+from .reader import (
+    Jiaocai1Book,
+    Jiaocai1Handle,
+    Jiaocai1Page,
+    Jiaocai1Reader,
+    Jiaocai1SearchResult,
+    section_starts,
+)
+
+__all__ = [
+    "JiaocaiBook",
+    "JiaocaiCatalog",
+    "Jiaocai1Book",
+    "Jiaocai1Handle",
+    "Jiaocai1Page",
+    "Jiaocai1Reader",
+    "Jiaocai1SearchResult",
+    "section_starts",
+]

--- a/jiaocai/catalog.py
+++ b/jiaocai/catalog.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from urllib.parse import quote
+
+import requests
+
+from .portal import follow_login_chain, needs_login
+
+
+SSNO_RE = re.compile(r"jiaocai1\.lib\.xjtu\.edu\.cn[^\"']*[?&]ssno=(\d+)|goRead\?ssno=(\d+)")
+TAG_RE = re.compile(r"<[^>]+>")
+
+
+@dataclass
+class JiaocaiBook:
+    book_id: str
+    app_id: int
+    engine_instance_id: int
+    title: str
+    author: str
+    summary: str
+    ssno: str = ""
+
+
+class JiaocaiCatalog:
+    BASE = "https://jiaocai.lib.xjtu.edu.cn"
+    FID = "17071"
+    PAGE_ID = "13858"
+    SEARCH_ID = "10700"
+
+    def __init__(self, session: requests.Session):
+        self.session = session
+
+    def _get(self, url: str) -> str:
+        response = self.session.get(
+            url,
+            headers={"Referer": f"{self.BASE}/", "X-Requested-With": "XMLHttpRequest"},
+            timeout=20,
+        )
+        body = response.text
+        if needs_login(body):
+            follow_login_chain(self.session, body)
+            body = self.session.get(
+                url,
+                headers={"Referer": f"{self.BASE}/", "X-Requested-With": "XMLHttpRequest"},
+                timeout=20,
+            ).text
+        return body
+
+    def search(self, keyword: str, page: int = 1, page_size: int = 20) -> list[JiaocaiBook]:
+        url = (
+            f"{self.BASE}/engine2/search/search-list"
+            f"?wfwfid={self.FID}&keyWord={quote(keyword)}"
+            f"&pageIndex={page}&pageSize={page_size}"
+            f"&pageId={self.PAGE_ID}&searchStrategy=0&searchId={self.SEARCH_ID}"
+        )
+        try:
+            payload = __import__("json").loads(self._get(url))
+        except ValueError:
+            return []
+        books = []
+        for item in ((payload.get("data") or {}).get("dataList") or []):
+            raw = str(item.get("content") or "")
+            match = SSNO_RE.search(raw)
+            books.append(JiaocaiBook(
+                book_id=str(item.get("id") or ""),
+                app_id=int(item.get("appId") or 0),
+                engine_instance_id=int(item.get("engineInstanceId") or 0),
+                title=TAG_RE.sub("", str(item.get("title") or "")),
+                author=str(item.get("author") or ""),
+                summary=TAG_RE.sub("", raw),
+                ssno=(match.group(1) or match.group(2)) if match else "",
+            ))
+        return books
+
+    def fetch_ssno(self, book: JiaocaiBook) -> str:
+        if book.ssno:
+            return book.ssno
+        numeric_id = book.book_id.rsplit("_", 1)[-1]
+        if not numeric_id:
+            return ""
+        html = self._get(
+            f"{self.BASE}/engine2/d/{numeric_id}/{book.engine_instance_id}/0/{book.app_id}"
+            f"?pageId={self.PAGE_ID}&engineInstanceId={book.engine_instance_id}"
+        )
+        match = SSNO_RE.search(html)
+        if match:
+            book.ssno = match.group(1) or match.group(2)
+        return book.ssno

--- a/jiaocai/portal.py
+++ b/jiaocai/portal.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import re
+from urllib.parse import urlparse
+
+import requests
+
+
+LOGOUT_URL_RE = re.compile(r'var\s+logoutUrl\s*=\s*"([^"]+)"')
+JS_UNICODE_RE = re.compile(r"\\u([0-9a-fA-F]{4})")
+ALLOWED_HOSTS = {"jiaocai.lib.xjtu.edu.cn", "jiaocai1.lib.xjtu.edu.cn", "login.xjtu.edu.cn"}
+MAX_HOPS = 5
+MAX_ROUNDS = 3
+
+
+def needs_login(body: str) -> bool:
+    return bool(LOGOUT_URL_RE.search(body))
+
+
+def unescape_js(value: str) -> str:
+    value = JS_UNICODE_RE.sub(lambda match: chr(int(match.group(1), 16)), value)
+    return value.replace("\\/", "/").replace('\\"', '"')
+
+
+def next_hop(body: str) -> str | None:
+    match = LOGOUT_URL_RE.search(body)
+    if not match:
+        return None
+    url = unescape_js(match.group(1))
+    host = urlparse(url).hostname or ""
+    if host not in ALLOWED_HOSTS:
+        return None
+    return url
+
+
+def follow_login_chain(session: requests.Session, start_page: str) -> bool:
+    page = start_page
+    seen: set[str] = set()
+    for _ in range(MAX_HOPS):
+        nxt = next_hop(page)
+        if not nxt:
+            return True
+        if nxt in seen:
+            return False
+        seen.add(nxt)
+        try:
+            page = session.get(nxt, timeout=20).text
+        except requests.RequestException:
+            return False
+    return False
+
+
+def decode_smart(content: bytes) -> str:
+    text = content.decode("utf-8", errors="replace")
+    if "\ufffd" in text:
+        return content.decode("gb18030", errors="replace")
+    return text

--- a/jiaocai/reader.py
+++ b/jiaocai/reader.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from html import unescape
+from typing import Iterable
+
+import requests
+
+from .portal import decode_smart, follow_login_chain, needs_login
+
+
+BASE = "https://jiaocai1.lib.xjtu.edu.cn"
+GUAJIE_BASE = "http://jiaocai1.lib.xjtu.edu.cn:9088"
+CHANNEL = "100"
+PREFIXES = ["cov", "bok", "leg", "fow", "!", "", "att", "cov"]
+TYPE_NAMES = ["封面", "书名页", "版权页", "前言", "目录", "正文", "附录", "封底"]
+LI_RE = re.compile(r"<li>(.*?)</li>", re.S)
+SSNO_RE = re.compile(r"goRead\?ssno=(\d+)")
+TITLE_RE = re.compile(r'<a[^>]*title="([^"]*)"')
+COVER_RE = re.compile(r'<img[^>]*\ssrc="([^"]+)"')
+DD_RE = re.compile(r"<dd>(.*?)</dd>", re.S)
+JPG_PATH_RE = re.compile(r'jpgPath:\s*"([^"]+)"')
+PAGES_RE = re.compile(r"var\s+pages\s*=\s*(\[\[.*?]]);")
+PAIR_RE = re.compile(r"\[\s*(-?\d+)\s*,\s*(-?\d+)\s*]")
+BOOK_PAGES_RE = re.compile(r"var\s+bookPages\s*=\s*(\d+)")
+HEAD_TITLE_RE = re.compile(r"<title>(.*?)</title>", re.S)
+TAG_RE = re.compile(r"<[^>]+>")
+
+
+@dataclass
+class Jiaocai1Book:
+    ssno: str
+    title: str
+    author: str = ""
+    publish_date: str = ""
+    theme: str = ""
+    call_no: str = ""
+    cover_url: str = ""
+
+
+@dataclass
+class Jiaocai1SearchResult:
+    books: list[Jiaocai1Book] = field(default_factory=list)
+    total_rows: int = 0
+    current_page: int = 1
+    total_pages: int = 1
+
+
+@dataclass
+class Jiaocai1Page:
+    index: int
+    type_index: int
+    num_in_type: int
+    file_name: str
+
+    @property
+    def type_name(self) -> str:
+        return TYPE_NAMES[self.type_index]
+
+    @property
+    def label(self) -> str:
+        if self.type_index == 5:
+            return f"第 {self.num_in_type} 页"
+        if self.type_index in {0, 1, 2, 7}:
+            return self.type_name
+        return f"{self.type_name} {self.num_in_type}"
+
+
+@dataclass
+class Jiaocai1Handle:
+    ssno: str
+    title: str
+    jpg_path: str
+    pages: list[Jiaocai1Page]
+
+
+def file_name(num_in_type: int, type_index: int) -> str:
+    prefix = PREFIXES[type_index]
+    digits = str(num_in_type)
+    pad = max(0, 6 - len(prefix) - len(digits))
+    return prefix + ("0" * pad) + digits
+
+
+def section_starts(pages: list[Jiaocai1Page]) -> list[tuple[str, int]]:
+    """各页型首页在线性页表里的下标，用于跳章。"""
+    starts: list[tuple[str, int]] = []
+    seen: set[int] = set()
+    for page in pages:
+        if page.type_index in seen:
+            continue
+        seen.add(page.type_index)
+        starts.append((page.type_name, page.index))
+    return starts
+
+
+def flatten(ranges: Iterable[tuple[int, int]]) -> list[Jiaocai1Page]:
+    pages = []
+    for type_index, (start, end) in enumerate(ranges):
+        if start > end or start <= 0:
+            continue
+        for number in range(start, end + 1):
+            pages.append(Jiaocai1Page(len(pages), type_index, number, file_name(number, type_index)))
+    return pages
+
+
+class Jiaocai1Reader:
+    def __init__(self, session: requests.Session):
+        self.session = session
+
+    def _request(self, method: str, url: str, **kwargs) -> str:
+        kwargs.setdefault("timeout", 20)
+        headers = dict(kwargs.pop("headers", {}))
+        headers.setdefault("Referer", f"{BASE}/front/")
+        headers.setdefault("X-Requested-With", "XMLHttpRequest")
+        response = self.session.request(method, url, headers=headers, **kwargs)
+        body = decode_smart(response.content)
+        if needs_login(body):
+            follow_login_chain(self.session, body)
+            response = self.session.request(method, url, headers=headers, **kwargs)
+            body = decode_smart(response.content)
+        return body
+
+    def search(self, keyword: str, field: str = "bookName", page: int = 1, cls: str = "") -> Jiaocai1SearchResult:
+        data = {
+            "cpage": str(page),
+            "stype": "1",
+            "orderField": "0",
+            "sw": keyword,
+            "searchField": field,
+        }
+        if cls:
+            data["cls"] = cls
+        html = self._request(
+            "POST",
+            f"{BASE}/front/book/search/index",
+            data=data,
+            headers={"Referer": f"{BASE}/front/book/search/page"},
+        )
+        books = []
+        for match in LI_RE.finditer(html):
+            block = match.group(1)
+            ssno_match = SSNO_RE.search(block)
+            if not ssno_match:
+                continue
+            fields = {}
+            for dd in DD_RE.finditer(block):
+                text = unescape(TAG_RE.sub("", dd.group(1))).strip()
+                if "：" in text:
+                    key, value = text.split("：", 1)
+                    fields[key.strip()] = value.strip()
+            books.append(Jiaocai1Book(
+                ssno=ssno_match.group(1),
+                title=unescape(TITLE_RE.search(block).group(1)).strip() if TITLE_RE.search(block) else "",
+                author=fields.get("作者", ""),
+                publish_date=fields.get("出版日期", ""),
+                theme=fields.get("主题词", ""),
+                call_no=fields.get("索书号", ""),
+                cover_url=unescape(COVER_RE.search(block).group(1)) if COVER_RE.search(block) else "",
+            ))
+        current = int(re.search(r'data-cpage="(\d+)"', html).group(1)) if re.search(r'data-cpage="(\d+)"', html) else page
+        total_pages = int(re.search(r'data-sum-page="(\d+)"', html).group(1)) if re.search(r'data-sum-page="(\d+)"', html) else 1
+        total_rows = int(re.search(r'data-totalrow="(\d+)"', html).group(1)) if re.search(r'data-totalrow="(\d+)"', html) else len(books)
+        return Jiaocai1SearchResult(books, total_rows, current, total_pages)
+
+    def open_book(self, ssno: str) -> Jiaocai1Handle | None:
+        handle = self._parse_reader(ssno, self._request("GET", f"{BASE}/front/reader/goRead?ssno={ssno}&channel={CHANNEL}&jpgread=1"))
+        if handle:
+            return handle
+        try:
+            return self._parse_reader(ssno, self._request("GET", f"{GUAJIE_BASE}/guajie/common?ssno={ssno}&cpage=1&channel={CHANNEL}"))
+        except requests.RequestException:
+            return None
+
+    def _parse_reader(self, ssno: str, html: str) -> Jiaocai1Handle | None:
+        jpg = JPG_PATH_RE.search(html)
+        pages_raw = PAGES_RE.search(html)
+        if not jpg or not pages_raw:
+            return None
+        ranges = [(int(a), int(b)) for a, b in PAIR_RE.findall(pages_raw.group(1))]
+        if len(ranges) != 8:
+            return None
+        title_match = HEAD_TITLE_RE.search(html)
+        return Jiaocai1Handle(
+            ssno=ssno,
+            title=unescape(title_match.group(1)).strip() if title_match else "",
+            jpg_path=jpg.group(1),
+            pages=flatten(ranges),
+        )
+
+    def page_url(self, handle: Jiaocai1Handle, page: Jiaocai1Page) -> str:
+        return f"{BASE}/jpath/{handle.jpg_path}{page.file_name}.jpg?zoom=0"
+
+    def fetch_page(self, handle: Jiaocai1Handle, page: Jiaocai1Page) -> bytes:
+        url = self.page_url(handle, page)
+        response = self.session.get(
+            url,
+            headers={"Referer": f"{BASE}/jpath/reader/reader.shtml"},
+            timeout=30,
+        )
+        if response.status_code != 200 or not response.content:
+            response = self.session.get(url, timeout=30)
+        return response.content


### PR DESCRIPTION
## Summary
- 工具箱增加教材全文：教材目录与全文库检索，打开后按页阅读。
- 阅读器默认双页、适合整页；支持拖拽平移、适合宽度、Ctrl+滚轮缩放。

## Test plan
- [x] 按书名检索并能打开全文
- [x] 双页能左右对照，翻页一次两页
- [x] 适合页面不裁掉底部；放大后可拖拽
- [x] 方向键 / 左右点按 / `D` 切换单双页可用
