### PR TITLE
feat: 图书馆座位查询与预约

### DIFF
--- a/app/HomeInterface.py
+++ b/app/HomeInterface.py
@@ -198,6 +198,13 @@ class HomeFrame(QWidget):
                 'content': self.tr("查看作业、课件与课程回放"),
                 'callback': lambda: self.main_window.switchTo(self.main_window.lms_interface),
                 'color': LinkCard.LinkCardColor.SKY_BLUE
+            },
+            "library": {
+                'icon': FIF.DOCUMENT.icon(theme=Theme.DARK),
+                'title': self.tr("图书馆"),
+                'content': self.tr("空座、预约、换座与签到"),
+                'callback': lambda: self.main_window.switchTo(self.main_window.library_interface),
+                'color': LinkCard.LinkCardColor.PURPLE
             }
         }
 

--- a/app/LibraryInterface.py
+++ b/app/LibraryInterface.py
@@ -3,7 +3,7 @@ from qfluentwidgets import BodyLabel, CheckBox, ComboBox, PrimaryPushButton, Pus
 
 from library import AREA_MAP, FLOORS, Library
 from .components.CampusPage import CampusPage
-from .utils import accounts
+from .utils import accounts, logger
 
 
 class LibraryInterface(CampusPage):
@@ -85,6 +85,7 @@ class LibraryInterface(CampusPage):
 
     def _sync_actions(self):
         actions = self.booking.action_urls if self.booking else {}
+        logger.info("library actions=%s booking=%s", list(actions), None if self.booking is None else self.booking.seat_id)
         self.checkinButton.setEnabled("入馆签到" in actions)
         self.leaveButton.setEnabled("中途离开" in actions)
         self.returnButton.setEnabled("中途返回" in actions)
@@ -146,7 +147,10 @@ class LibraryInterface(CampusPage):
     def _on_book(self, result):
         if result.success:
             self.success(self.tr("预约成功"), result.message)
-            self.refresh_booking()
+            if result.booking:
+                self._on_booking(result.booking)
+            if not (result.booking and result.booking.action_urls):
+                self.refresh_booking()
         else:
             self.warn(self.tr("预约失败"), result.message)
 
@@ -156,16 +160,19 @@ class LibraryInterface(CampusPage):
         self.start_job("library", self.tr("正在查询预约..."), lambda session: Library(session).get_my_booking(), self._on_booking)
 
     def _on_booking(self, booking):
+        if booking and self.booking and not booking.action_urls and self.booking.action_urls:
+            booking.action_urls = dict(self.booking.action_urls)
         self.booking = booking
         self._sync_actions()
         if booking is None:
             self.bookingLabel.setText(self.tr("当前没有有效预约"))
             return
-        self.bookingLabel.setText(
-            self.tr("当前预约：{seat}  {area}  {status}").format(
-                seat=booking.seat_id, area=booking.area, status=booking.status_text,
-            )
+        text = self.tr("当前预约：{seat}  {area}  {status}").format(
+            seat=booking.seat_id, area=booking.area, status=booking.status_text,
         )
+        if not booking.action_urls:
+            text += self.tr("；未识别到操作按钮，详情已写入日志")
+        self.bookingLabel.setText(text)
 
     def run_action(self, label: str):
         if not self.require_account():

--- a/app/LibraryInterface.py
+++ b/app/LibraryInterface.py
@@ -1,0 +1,168 @@
+from PyQt5.QtWidgets import QTableWidgetItem
+from qfluentwidgets import BodyLabel, CheckBox, ComboBox, PrimaryPushButton, PushButton
+
+from library import AREA_MAP, FLOORS, Library
+from .components.CampusPage import CampusPage
+from .utils import accounts
+
+
+class LibraryInterface(CampusPage):
+    def __init__(self, parent=None):
+        super().__init__("libraryInterface", "图书馆座位", "查空座、预约、换座、取消与签到", parent)
+        self.seats = []
+        self.booking = None
+        self._booking_loaded = False
+
+        self.floorBox = ComboBox(self.view)
+        self.areaBox = ComboBox(self.view)
+        self.areaBox.setMinimumWidth(220)
+        for floor in FLOORS:
+            self.floorBox.addItem(floor)
+        self.floorBox.currentTextChanged.connect(self._reload_areas)
+        self._reload_areas(self.floorBox.currentText())
+        self.freeOnly = CheckBox(self.tr("只看空闲"), self.view)
+        self.freeOnly.setChecked(True)
+        self.freeOnly.stateChanged.connect(self._render_seats)
+        self.queryButton = PrimaryPushButton(self.tr("查询座位"), self.view)
+        self.queryButton.clicked.connect(self.query_seats)
+        self.add_toolbar(
+            self.labeled(self.tr("楼层"), self.floorBox),
+            self.labeled(self.tr("区域"), self.areaBox, width=40),
+            self.freeOnly,
+            self.queryButton,
+        )
+
+        self.bookingLabel = BodyLabel(self.tr("打开本页会自动查询当前预约。"), self.view)
+        self.bookingLabel.setWordWrap(True)
+        self.vBoxLayout.addWidget(self.bookingLabel)
+
+        self.bookButton = PrimaryPushButton(self.tr("预约选中座位"), self.view)
+        self.refreshBookButton = PushButton(self.tr("刷新预约"), self.view)
+        self.checkinButton = PushButton(self.tr("入馆签到"), self.view)
+        self.leaveButton = PushButton(self.tr("中途离开"), self.view)
+        self.returnButton = PushButton(self.tr("中途返回"), self.view)
+        self.cancelButton = PushButton(self.tr("取消预约"), self.view)
+        self.bookButton.clicked.connect(self.book_selected)
+        self.refreshBookButton.clicked.connect(self.refresh_booking)
+        self.cancelButton.clicked.connect(lambda: self.run_action("取消预约"))
+        self.checkinButton.clicked.connect(lambda: self.run_action("入馆签到"))
+        self.leaveButton.clicked.connect(lambda: self.run_action("中途离开"))
+        self.returnButton.clicked.connect(lambda: self.run_action("中途返回"))
+        self.add_toolbar(
+            self.bookButton,
+            self.refreshBookButton,
+            self.checkinButton,
+            self.leaveButton,
+            self.returnButton,
+            self.cancelButton,
+        )
+        self._sync_actions()
+
+        self.table = self.make_table([self.tr("座位"), self.tr("状态")])
+        self.table.doubleClicked.connect(self.book_selected)
+        self.vBoxLayout.addWidget(self.table, 1)
+
+    def showEvent(self, event):
+        super().showEvent(event)
+        if self._booking_loaded or accounts.current is None:
+            return
+        self._booking_loaded = True
+        self.refresh_booking()
+
+    def _reload_areas(self, floor: str):
+        self.areaBox.clear()
+        for name in FLOORS.get(floor, []):
+            self.areaBox.addItem(name, userData=AREA_MAP.get(name))
+
+    def _sync_actions(self):
+        actions = self.booking.action_urls if self.booking else {}
+        self.checkinButton.setEnabled("入馆签到" in actions)
+        self.leaveButton.setEnabled("中途离开" in actions)
+        self.returnButton.setEnabled("中途返回" in actions)
+        self.cancelButton.setEnabled("取消预约" in actions)
+
+    def query_seats(self):
+        if not self.require_account():
+            return
+        area_code = self.areaBox.currentData()
+        if not area_code:
+            self.warn(self.tr("未选择区域"), self.tr("请先选择楼层和区域"))
+            return
+        self.start_job("library", self.tr("正在查询座位..."), lambda session: Library(session).get_seats(area_code), self._on_seats)
+
+    def _on_seats(self, payload):
+        seats, stats = payload
+        self.seats = seats
+        self._render_seats()
+        area_code = self.areaBox.currentData()
+        stat = stats.get(area_code)
+        extra = f" {stat.available}/{stat.total}" if stat else ""
+        self.success(self.tr("查询成功"), self.tr("空闲 {count} 个{extra}").format(
+            count=sum(1 for seat in seats if seat.available), extra=extra,
+        ))
+
+    def _render_seats(self):
+        rows = [seat for seat in self.seats if seat.available] if self.freeOnly.isChecked() else self.seats
+        self.table.setRowCount(len(rows))
+        for row, seat in enumerate(rows):
+            self.table.setItem(row, 0, QTableWidgetItem(seat.seat_id))
+            self.table.setItem(row, 1, QTableWidgetItem(self.tr("空闲") if seat.available else self.tr("占用")))
+        self._visible_seats = rows
+
+    def _selected_seat(self):
+        row = self.table.currentRow()
+        seats = getattr(self, "_visible_seats", self.seats)
+        if row < 0 or row >= len(seats):
+            return None
+        return seats[row]
+
+    def book_selected(self):
+        if not self.require_account():
+            return
+        seat = self._selected_seat()
+        if seat is None:
+            self.warn(self.tr("未选择座位"), self.tr("请先在表格中选择座位"))
+            return
+        if not seat.available:
+            self.warn(self.tr("座位占用"), self.tr("请选择空闲座位"))
+            return
+        area_code = self.areaBox.currentData()
+        self.start_job(
+            "library",
+            self.tr("正在预约座位..."),
+            lambda session: Library(session).book_seat(seat.seat_id, area_code),
+            self._on_book,
+        )
+
+    def _on_book(self, result):
+        if result.success:
+            self.success(self.tr("预约成功"), result.message)
+            self.refresh_booking()
+        else:
+            self.warn(self.tr("预约失败"), result.message)
+
+    def refresh_booking(self):
+        if not self.require_account():
+            return
+        self.start_job("library", self.tr("正在查询预约..."), lambda session: Library(session).get_my_booking(), self._on_booking)
+
+    def _on_booking(self, booking):
+        self.booking = booking
+        self._sync_actions()
+        if booking is None:
+            self.bookingLabel.setText(self.tr("当前没有有效预约"))
+            return
+        self.bookingLabel.setText(
+            self.tr("当前预约：{seat}  {area}  {status}").format(
+                seat=booking.seat_id, area=booking.area, status=booking.status_text,
+            )
+        )
+
+    def run_action(self, label: str):
+        if not self.require_account():
+            return
+        if not self.booking or label not in self.booking.action_urls:
+            self.warn(self.tr("无法操作"), self.tr("请先刷新预约，或当前预约没有该操作"))
+            return
+        url = self.booking.action_urls[label]
+        self.start_job("library", self.tr("正在执行操作..."), lambda session: Library(session).execute_action(url), self._on_book)

--- a/app/LibraryInterface.py
+++ b/app/LibraryInterface.py
@@ -59,8 +59,17 @@ class LibraryInterface(CampusPage):
         self._sync_actions()
 
         self.table = self.make_table([self.tr("座位"), self.tr("状态")])
-        self.table.doubleClicked.connect(self.book_selected)
+        self.table.doubleClicked.connect(lambda _index: self.book_selected())
         self.vBoxLayout.addWidget(self.table, 1)
+
+    def on_account_changed(self):
+        self._booking_loaded = False
+        self.seats = []
+        self.booking = None
+        self._visible_seats = []
+        self.bookingLabel.setText(self.tr("打开本页会自动查询当前预约。"))
+        self.table.setRowCount(0)
+        self._sync_actions()
 
     def showEvent(self, event):
         super().showEvent(event)

--- a/app/components/CampusPage.py
+++ b/app/components/CampusPage.py
@@ -1,0 +1,113 @@
+from PyQt5.QtWidgets import QFrame, QHBoxLayout, QHeaderView, QVBoxLayout, QWidget
+from qfluentwidgets import BodyLabel, InfoBar, InfoBarPosition, ScrollArea, StrongBodyLabel, TableWidget, TitleLabel
+
+from app.threads.CampusFeatureThread import CampusFeatureThread
+from app.threads.ProcessWidget import ProcessWidget
+from app.utils import StyleSheet, accounts
+
+
+class CampusPage(ScrollArea):
+    """Shared chrome for newly ported campus tools."""
+
+    def __init__(self, object_name: str, title: str, subtitle: str, parent=None):
+        super().__init__(parent)
+        self.setObjectName(object_name)
+        self.view = QWidget(self)
+        self.view.setObjectName("view")
+        self.vBoxLayout = QVBoxLayout(self.view)
+        self.vBoxLayout.setContentsMargins(24, 24, 24, 40)
+        self.vBoxLayout.setSpacing(10)
+        self.titleLabel = TitleLabel(title, self.view)
+        self.titleLabel.setContentsMargins(10, 15, 0, 0)
+        self.vBoxLayout.addWidget(self.titleLabel)
+        self.minorLabel = StrongBodyLabel(subtitle, self.view)
+        self.minorLabel.setContentsMargins(15, 5, 0, 0)
+        self.vBoxLayout.addWidget(self.minorLabel)
+
+        self.jobSlot = QWidget(self.view)
+        self.jobLayout = QVBoxLayout(self.jobSlot)
+        self.jobLayout.setContentsMargins(0, 0, 0, 0)
+        self.jobLayout.setSpacing(0)
+        self.vBoxLayout.addWidget(self.jobSlot)
+        self.thread = None
+        self.processWidget = None
+
+        StyleSheet.EMPTY_ROOM_INTERFACE.apply(self)
+        self.setWidgetResizable(True)
+        self.setWidget(self.view)
+        self._notice = None
+
+    def add_toolbar(self, *widgets) -> QFrame:
+        bar = QFrame(self.view)
+        layout = QHBoxLayout(bar)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(8)
+        for widget in widgets:
+            if widget is not None:
+                layout.addWidget(widget)
+        layout.addStretch(1)
+        self.vBoxLayout.addWidget(bar)
+        return bar
+
+    def labeled(self, text: str, widget: QWidget, width: int = 56) -> QFrame:
+        box = QFrame(self.view)
+        layout = QHBoxLayout(box)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(6)
+        label = BodyLabel(text, box)
+        label.setFixedWidth(width)
+        layout.addWidget(label)
+        layout.addWidget(widget)
+        return box
+
+    def make_table(self, headers: list[str]) -> TableWidget:
+        table = TableWidget(self.view)
+        table.setColumnCount(len(headers))
+        table.setHorizontalHeaderLabels(headers)
+        table.horizontalHeader().setSectionResizeMode(QHeaderView.ResizeToContents)
+        table.horizontalHeader().setStretchLastSection(True)
+        table.verticalHeader().setVisible(False)
+        table.setEditTriggers(TableWidget.NoEditTriggers)
+        table.setWordWrap(True)
+        table.setAlternatingRowColors(True)
+        table.setSelectionBehavior(TableWidget.SelectRows)
+        return table
+
+    def start_job(self, site_key: str, message: str, worker, on_result, need_login: bool = True,
+                  show_process: bool = True) -> bool:
+        if self.thread is not None and self.thread.isRunning():
+            self.thread.can_run = False
+        self.thread = CampusFeatureThread(site_key, message, worker, need_login=need_login, parent=self)
+        if self.processWidget:
+            self.processWidget.deleteLater()
+            self.processWidget = None
+        if show_process:
+            self.processWidget = ProcessWidget(self.thread, self.jobSlot, hide_on_end=True)
+            self.jobLayout.addWidget(self.processWidget)
+        self.thread.result.connect(on_result)
+        self.thread.error.connect(self.warn)
+        self.thread.start()
+        return True
+
+    def require_account(self) -> bool:
+        if accounts.current is None:
+            self.warn(self.tr("未登录"), self.tr("请先添加一个账户"))
+            return False
+        return True
+
+    def info(self, title: str, msg: str) -> None:
+        self._bar(InfoBar.info, title, msg)
+
+    def success(self, title: str, msg: str) -> None:
+        self._bar(InfoBar.success, title, msg)
+
+    def warn(self, title: str, msg: str) -> None:
+        self._bar(InfoBar.warning, title, msg)
+
+    def _bar(self, factory, title: str, msg: str) -> None:
+        if self._notice is not None:
+            try:
+                self._notice.close()
+            except RuntimeError:
+                self._notice = None
+        self._notice = factory(title, msg, duration=2500, position=InfoBarPosition.TOP_RIGHT, parent=self)

--- a/app/components/CampusPage.py
+++ b/app/components/CampusPage.py
@@ -1,3 +1,4 @@
+from PyQt5.QtCore import pyqtSlot
 from PyQt5.QtWidgets import QFrame, QHBoxLayout, QHeaderView, QVBoxLayout, QWidget
 from qfluentwidgets import BodyLabel, InfoBar, InfoBarPosition, ScrollArea, StrongBodyLabel, TableWidget, TitleLabel
 
@@ -31,6 +32,7 @@ class CampusPage(ScrollArea):
         self.vBoxLayout.addWidget(self.jobSlot)
         self.thread = None
         self.processWidget = None
+        accounts.currentAccountChanged.connect(self._on_current_account_changed)
 
         StyleSheet.EMPTY_ROOM_INTERFACE.apply(self)
         self.setWidgetResizable(True)
@@ -77,6 +79,7 @@ class CampusPage(ScrollArea):
                   show_process: bool = True) -> bool:
         if self.thread is not None and self.thread.isRunning():
             self.thread.can_run = False
+        started_uuid = getattr(accounts.current, "uuid", None)
         self.thread = CampusFeatureThread(site_key, message, worker, need_login=need_login, parent=self)
         if self.processWidget:
             self.processWidget.deleteLater()
@@ -84,10 +87,26 @@ class CampusPage(ScrollArea):
         if show_process:
             self.processWidget = ProcessWidget(self.thread, self.jobSlot, hide_on_end=True)
             self.jobLayout.addWidget(self.processWidget)
-        self.thread.result.connect(on_result)
+
+        def _guarded(payload):
+            current = accounts.current
+            if started_uuid is None or current is None or getattr(current, "uuid", None) != started_uuid:
+                return
+            on_result(payload)
+
+        self.thread.result.connect(_guarded)
         self.thread.error.connect(self.warn)
         self.thread.start()
         return True
+
+    @pyqtSlot()
+    def _on_current_account_changed(self):
+        if self.thread is not None and self.thread.isRunning():
+            self.thread.can_run = False
+        self.on_account_changed()
+
+    def on_account_changed(self):
+        """Reset page-owned state after the current account changes."""
 
     def require_account(self) -> bool:
         if accounts.current is None:

--- a/app/main_window.py
+++ b/app/main_window.py
@@ -32,6 +32,8 @@ from .sessions.gste_session import GSTESession
 from .sessions.jwapp_session import JwappSession
 from .sessions.lms_session import LMSSession
 from .sessions.venue_session import VenueSession
+from .sessions.library_session import LibrarySession
+from .LibraryInterface import LibraryInterface
 from .sub_interfaces import LoginInterface
 from .sub_interfaces.QRCodeLoginDialog import QRCodeLoginDialog
 from .sub_interfaces.VerifyCodeDialog import VerifyCodeDialog
@@ -62,6 +64,7 @@ def registerSession():
     SessionManager.global_register(GSTESession, "gste")
     SessionManager.global_register(LMSSession, "lms")
     SessionManager.global_register(VenueSession, "venue")
+    SessionManager.global_register(LibrarySession, "library")
 
 
 class MacReopenFilter(QObject):
@@ -202,6 +205,8 @@ class MainWindow(MSFluentWindow):
         QApplication.processEvents()
         self.venue_interface = VenueInterface(self)
         QApplication.processEvents()
+        self.library_interface = LibraryInterface(self)
+        QApplication.processEvents()
 
         self.tray_interface = TrayInterface(QIcon("assets/icons/main_icon.ico"))
         self.tray_interface.main_interface.connect(lambda: self.show())
@@ -326,6 +331,7 @@ class MainWindow(MSFluentWindow):
         self.addSubInterface(self.score_interface, FIF.EDUCATION, self.tr("成绩"))
         self.addSubInterface(self.lms_interface, FIF.DOCUMENT, self.tr("思源学堂"))
         self.addSubInterface(self.venue_interface, FIF.BASKETBALL, self.tr("体育场馆"))
+        self.addSubInterface(self.library_interface, FIF.BOOK_SHELF, self.tr("图书馆"))
         self.addSubInterface(self.tool_box_interface, FIF.APPLICATION, self.tr("工具"))
 
         self.navigationInterface.addWidget("GitHub",
@@ -363,6 +369,7 @@ class MainWindow(MSFluentWindow):
         empty_room_card = self.tool_box_interface.addCard(self.empty_room_interface, FIF.LAYOUT, self.tr("空闲教室"),
                                                           self.tr("查询当前空闲的教室"))
         empty_room_card.setFixedSize(200, 180)
+
 
         # 添加登录界面作为子界面，但是将其隐藏
         button = self.addSubInterface(self.login_interface, FIF.SCROLL, self.tr("登录"),

--- a/app/sessions/common_session.py
+++ b/app/sessions/common_session.py
@@ -64,6 +64,8 @@ class CommonLoginSession(metaclass=ABCMeta):
     supports_webvpn = False
     # 自动检测为校外网络时，当前站点是否需要通过 WebVPN 访问。
     use_webvpn_when_off_campus = True
+    # 非空时覆盖共享后端的桌面 UA。一卡通、图书馆座位等站点会校验移动端标识。
+    user_agent = ""
 
     def __init__(self, backend: SessionBackend | None = None, site_key: str | None = None,
                  timeout: int = 15 * 60) -> None:
@@ -193,6 +195,8 @@ class CommonLoginSession(metaclass=ABCMeta):
                 raise TypeError("headers should be a mapping")
             for key, value in request_headers.items():
                 headers[str(key)] = str(value)
+        if self.user_agent:
+            headers["User-Agent"] = self.user_agent
 
         prepared_url = self.prepare_url_for_access_mode(url, skip_webvpn_rewrite=skip_webvpn_rewrite)
         prepared_headers = self.prepare_headers_for_access_mode(headers, skip_webvpn_rewrite=skip_webvpn_rewrite)

--- a/app/sessions/common_session.py
+++ b/app/sessions/common_session.py
@@ -17,6 +17,19 @@ import requests.structures
 from auth import NewLogin, QRCodeLoginMixin, ServerError, is_safety_verify_page
 from .session_backend import AccessMode, SessionBackend
 
+
+def http_safe_headers(headers: Mapping) -> dict[str, str]:
+    """Drop header values HTTP cannot send (e.g. Chinese names stuffed into site state)."""
+    safe: dict[str, str] = {}
+    for key, value in headers.items():
+        text = "" if value is None else str(value)
+        try:
+            text.encode("latin-1")
+        except UnicodeEncodeError:
+            continue
+        safe[str(key)] = text
+    return safe
+
 if TYPE_CHECKING:
     from app.utils.account import Account
     from app.utils.mfa import MFAProvider
@@ -199,7 +212,9 @@ class CommonLoginSession(metaclass=ABCMeta):
             headers["User-Agent"] = self.user_agent
 
         prepared_url = self.prepare_url_for_access_mode(url, skip_webvpn_rewrite=skip_webvpn_rewrite)
-        prepared_headers = self.prepare_headers_for_access_mode(headers, skip_webvpn_rewrite=skip_webvpn_rewrite)
+        prepared_headers = http_safe_headers(
+            self.prepare_headers_for_access_mode(headers, skip_webvpn_rewrite=skip_webvpn_rewrite)
+        )
         response = self.backend.session.request(method, prepared_url, headers=prepared_headers, **kwargs)
         if skip_auth_check or self._login_depth > 0 or not self.is_auth_failure_response(response):
             return response

--- a/app/sessions/library_session.py
+++ b/app/sessions/library_session.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from auth import ServerError
+from auth.constant import LIBRARY_LOGIN_URL, MOBILE_BROWSER_UA
+from auth.new_login import NewLogin, NewWebVPNLogin
+from .common_session import CommonLoginSession
+from .session_backend import AccessMode
+from ..utils import cfg
+
+
+def looks_like_seat_page(body: str) -> bool:
+    if "移动端模式" in body:
+        return False
+    return any(marker in body for marker in ("btn-group", "tab-select", "qseat", "座位", "scount"))
+
+
+class LibrarySession(CommonLoginSession):
+    """rg.lib.xjtu.edu.cn:8086 座位系统，CAS cookie 会话。"""
+
+    site_key = "library"
+    site_name = "图书馆"
+    supports_webvpn = True
+    use_webvpn_when_off_campus = True
+    user_agent = MOBILE_BROWSER_UA
+
+    def _login(self, username: str, password: str, **kwargs: object) -> None:
+        login_class = NewWebVPNLogin if self.access_mode == AccessMode.WEBVPN else NewLogin
+        self.perform_cas_login(
+            username,
+            password,
+            kwargs=kwargs,
+            password_login_factory=lambda: login_class(
+                LIBRARY_LOGIN_URL, session=self, visitor_id=str(cfg.loginId.value)
+            ),
+            qrcode_login_factory=None,
+            allow_qrcode_login=False,
+        )
+        response = self.get(LIBRARY_LOGIN_URL, allow_redirects=True, timeout=20, _skip_auth_check=True)
+        if "移动端模式" in response.text:
+            raise ServerError(1, "请浏览器调成移动端模式访问！")
+        if not looks_like_seat_page(response.text):
+            raise ServerError(1, "图书馆座位系统登录失败，请确认已连接校园网或 WebVPN")
+        self.reset_timeout()
+        self.has_login = True
+
+    _re_login = _login
+
+    def validate_login(self) -> bool:
+        response = self.get(LIBRARY_LOGIN_URL, timeout=10, _skip_auth_check=True)
+        if not response.ok or self.is_auth_failure_response(response):
+            return False
+        return looks_like_seat_page(response.text)

--- a/app/threads/CampusFeatureThread.py
+++ b/app/threads/CampusFeatureThread.py
@@ -1,0 +1,39 @@
+from collections.abc import Callable
+from typing import Any
+
+from PyQt5.QtCore import pyqtSignal
+
+from app.threads.ProcessWidget import ProcessThread
+from app.utils.campus_job import run_campus_job
+
+
+class CampusFeatureThread(ProcessThread):
+    """Login a campus site (optional) and run a worker on a background thread."""
+
+    result = pyqtSignal(object)
+
+    def __init__(
+            self,
+            site_key: str,
+            login_message: str,
+            worker: Callable[[Any], Any],
+            need_login: bool = True,
+            parent=None):
+        super().__init__(parent)
+        self.site_key = site_key
+        self.login_message = login_message
+        self.worker = worker
+        self.need_login = need_login
+
+    def run(self):
+        payload = run_campus_job(
+            self,
+            site_key=self.site_key,
+            login_message=self.login_message,
+            worker=self.worker,
+            need_login=self.need_login,
+        )
+        if payload is None:
+            return
+        self.result.emit(payload)
+        self.hasFinished.emit()

--- a/app/threads/CampusFeatureThread.py
+++ b/app/threads/CampusFeatureThread.py
@@ -4,7 +4,7 @@ from typing import Any
 from PyQt5.QtCore import pyqtSignal
 
 from app.threads.ProcessWidget import ProcessThread
-from app.utils.campus_job import run_campus_job
+from app.utils.campus_job import JOB_FAILED, run_campus_job
 
 
 class CampusFeatureThread(ProcessThread):
@@ -33,7 +33,7 @@ class CampusFeatureThread(ProcessThread):
             worker=self.worker,
             need_login=self.need_login,
         )
-        if payload is None:
+        if payload is JOB_FAILED:
             return
         self.result.emit(payload)
         self.hasFinished.emit()

--- a/app/utils/campus_job.py
+++ b/app/utils/campus_job.py
@@ -13,6 +13,9 @@ from app.utils import accounts, logger
 from app.utils.mfa import MFACancelledError, MFAUnavailableError
 from app.utils.qrcode_login import QRCodeLoginCancelledError, QRCodeLoginUnavailableError
 
+# Distinguishes a failed/canceled job from a worker that legitimately returned None.
+JOB_FAILED = object()
+
 
 def run_campus_job(
         thread: ProcessThread,
@@ -21,37 +24,40 @@ def run_campus_job(
         login_message: str,
         worker: Callable[[Any], Any],
         need_login: bool = True) -> Any:
-    """Login the current account into ``site_key`` (optional) and run ``worker``.
+    """Login a captured account into ``site_key`` (optional) and run ``worker``.
 
-    ``worker`` receives the site session (or ``None`` when ``need_login`` is false).
-    The function emits the usual ProcessThread error/cancel signals and returns
-    the worker result on success. The caller should emit ``result`` / ``hasFinished``.
+    The current account is snapshotted at start so a mid-job account switch cannot
+    mix credentials. ``worker`` receives the site session (or ``None`` when
+    ``need_login`` is false). Failure paths return ``JOB_FAILED``; a successful
+    worker may still return ``None``.
     """
     thread.can_run = True
-    if need_login and accounts.current is None:
+    account = accounts.current
+    if need_login and account is None:
         thread.error.emit(thread.tr("未登录"), thread.tr("请先添加一个账户"))
         thread.canceled.emit()
-        return None
+        thread.can_run = False
+        return JOB_FAILED
 
     try:
         session = None
         if need_login:
-            session = accounts.current.session_manager.get_session(site_key)
+            session = account.session_manager.get_session(site_key)
             thread.setIndeterminate.emit(True)
             thread.messageChanged.emit(login_message)
             session.ensure_login(
-                accounts.current.username,
-                accounts.current.password,
-                account=accounts.current,
-                mfa_provider=accounts.current.session_manager.mfa_provider,
+                account.username,
+                account.password,
+                account=account,
+                mfa_provider=account.session_manager.mfa_provider,
             )
             if not thread.can_run:
                 thread.canceled.emit()
-                return None
+                return JOB_FAILED
         result = worker(session)
         if not thread.can_run:
             thread.canceled.emit()
-            return None
+            return JOB_FAILED
         return result
     except QRCodeLoginCancelledError as e:
         logger.info("二维码登录已取消：%s", e)
@@ -76,7 +82,8 @@ def run_campus_job(
                 thread.tr("登录问题"),
                 thread.tr("需要进行两步验证，请前往账户界面，选择对应账户进行验证。"),
             )
-            accounts.current.MFASignal.emit(True)
+            if account is not None:
+                account.MFASignal.emit(True)
         else:
             thread.error.emit(thread.tr("服务器错误"), e.message)
         thread.canceled.emit()
@@ -92,4 +99,5 @@ def run_campus_job(
         logger.error("其他错误", exc_info=True)
         thread.error.emit(thread.tr("其他错误"), str(e))
         thread.canceled.emit()
-    return None
+    thread.can_run = False
+    return JOB_FAILED

--- a/app/utils/campus_job.py
+++ b/app/utils/campus_job.py
@@ -1,0 +1,95 @@
+"""Shared login + error handling for campus feature worker threads."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import requests
+
+from auth import ServerError
+from app.threads.ProcessWidget import ProcessThread
+from app.utils import accounts, logger
+from app.utils.mfa import MFACancelledError, MFAUnavailableError
+from app.utils.qrcode_login import QRCodeLoginCancelledError, QRCodeLoginUnavailableError
+
+
+def run_campus_job(
+        thread: ProcessThread,
+        *,
+        site_key: str,
+        login_message: str,
+        worker: Callable[[Any], Any],
+        need_login: bool = True) -> Any:
+    """Login the current account into ``site_key`` (optional) and run ``worker``.
+
+    ``worker`` receives the site session (or ``None`` when ``need_login`` is false).
+    The function emits the usual ProcessThread error/cancel signals and returns
+    the worker result on success. The caller should emit ``result`` / ``hasFinished``.
+    """
+    thread.can_run = True
+    if need_login and accounts.current is None:
+        thread.error.emit(thread.tr("未登录"), thread.tr("请先添加一个账户"))
+        thread.canceled.emit()
+        return None
+
+    try:
+        session = None
+        if need_login:
+            session = accounts.current.session_manager.get_session(site_key)
+            thread.setIndeterminate.emit(True)
+            thread.messageChanged.emit(login_message)
+            session.ensure_login(
+                accounts.current.username,
+                accounts.current.password,
+                account=accounts.current,
+                mfa_provider=accounts.current.session_manager.mfa_provider,
+            )
+            if not thread.can_run:
+                thread.canceled.emit()
+                return None
+        result = worker(session)
+        if not thread.can_run:
+            thread.canceled.emit()
+            return None
+        return result
+    except QRCodeLoginCancelledError as e:
+        logger.info("二维码登录已取消：%s", e)
+        thread.error.emit(thread.tr("扫码登录已取消"), thread.tr("已取消扫码登录，本次操作未完成。"))
+        thread.canceled.emit()
+    except QRCodeLoginUnavailableError as e:
+        logger.error("二维码登录交互不可用", exc_info=True)
+        thread.error.emit(thread.tr("登录问题"), str(e))
+        thread.canceled.emit()
+    except MFACancelledError as e:
+        logger.info("MFA 验证已取消：%s", e)
+        thread.error.emit(thread.tr("安全验证已取消"), thread.tr("已取消安全验证，本次操作未完成。"))
+        thread.canceled.emit()
+    except MFAUnavailableError as e:
+        logger.error("MFA 交互不可用", exc_info=True)
+        thread.error.emit(thread.tr("登录问题"), str(e))
+        thread.canceled.emit()
+    except ServerError as e:
+        logger.error("服务器错误", exc_info=True)
+        if e.code == 102:
+            thread.error.emit(
+                thread.tr("登录问题"),
+                thread.tr("需要进行两步验证，请前往账户界面，选择对应账户进行验证。"),
+            )
+            accounts.current.MFASignal.emit(True)
+        else:
+            thread.error.emit(thread.tr("服务器错误"), e.message)
+        thread.canceled.emit()
+    except requests.ConnectionError:
+        logger.error("网络错误", exc_info=True)
+        thread.error.emit(thread.tr("无网络连接"), thread.tr("请检查网络连接，然后重试。"))
+        thread.canceled.emit()
+    except requests.RequestException as e:
+        logger.error("网络错误", exc_info=True)
+        thread.error.emit(thread.tr("网络错误"), str(e))
+        thread.canceled.emit()
+    except Exception as e:
+        logger.error("其他错误", exc_info=True)
+        thread.error.emit(thread.tr("其他错误"), str(e))
+        thread.canceled.emit()
+    return None

--- a/auth/constant.py
+++ b/auth/constant.py
@@ -31,3 +31,12 @@ YWTB_LOGIN_URL = "https://login.xjtu.edu.cn/cas/login?service=https%3A%2F%2Fywtb
 GMIS_LOGIN_URL = "https://org.xjtu.edu.cn/openplatform/oauth/authorize?appId=1036&state=abcd1234&redirectUri=http://gmis.xjtu.edu.cn/pyxx/sso/login&responseType=code&scope=user_info"
 # 研究生评教系统的登录地址
 GSTE_LOGIN_URL = "https://cas.xjtu.edu.cn/login?TARGET=http%3A%2F%2Fgste.xjtu.edu.cn%2Flogin.do"
+
+# 一卡通 / 图书馆座位等 H5 接口会校验 UA，桌面 Chrome 会被直接拒绝。
+MOBILE_BROWSER_UA = (
+    "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/131.0.0.0 Mobile Safari/537.36"
+)
+
+# 图书馆座位
+LIBRARY_LOGIN_URL = "http://rg.lib.xjtu.edu.cn:8086/seat/"

--- a/library/__init__.py
+++ b/library/__init__.py
@@ -1,0 +1,10 @@
+from .seats import (
+    AREA_MAP,
+    FLOORS,
+    BookResult,
+    Library,
+    MyBooking,
+    SeatInfo,
+)
+
+__all__ = ["AREA_MAP", "FLOORS", "BookResult", "Library", "MyBooking", "SeatInfo"]

--- a/library/seats.py
+++ b/library/seats.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import logging
+import os
 import re
 import time
 from dataclasses import dataclass, field
@@ -11,10 +13,14 @@ from lxml import html as lxml_html
 
 from auth.constant import MOBILE_BROWSER_UA
 
+logger = logging.getLogger("default")
+
 
 BASE_URL = "http://rg.lib.xjtu.edu.cn:8086"
 SEAT_ID_RE = re.compile(r"(?:[A-Z]\d{2,4}|\b\d{3}\b)")
-CONFIRM_RE = re.compile(r"showConfirmModal\s*\(\s*['\"][^'\"]*['\"]\s*,\s*'(\w+)'\s*,\s*'(\d+)'\s*\)")
+CONFIRM_RE = re.compile(
+    r"showConfirmModal\s*\(\s*['\"][^'\"]*['\"]\s*,\s*['\"](\w+)['\"]\s*,\s*['\"](\d+)['\"]\s*\)"
+)
 MOBILE_UA = MOBILE_BROWSER_UA
 MOBILE_ONLY_HINT = "移动端模式"
 
@@ -66,6 +72,7 @@ class BookResult:
     success: bool
     message: str
     final_url: str = ""
+    booking: MyBooking | None = None
 
 
 @dataclass
@@ -150,8 +157,15 @@ class Library:
 
     def book_seat(self, seat_id: str, area_code: str, auto_swap: bool = True) -> BookResult:
         response = self._get(f"{BASE_URL}/seat/?kid={seat_id}&sp={area_code}")
-        if "/my/" in response.url or "/seat/my/" in response.url:
-            return BookResult(True, f"座位 {seat_id} 预约成功", response.url)
+        logger.info("book_seat: seat=%s area=%s url=%s len=%s", seat_id, area_code, response.url, len(response.text))
+        if self._is_my_page(response.url):
+            booking = self._booking_from_html(response.text, response.url)
+            logger.info(
+                "book_seat: landed on my-page booking=%s actions=%s",
+                None if booking is None else f"{booking.seat_id}/{booking.status_text}",
+                list(booking.action_urls) if booking else [],
+            )
+            return BookResult(True, f"座位 {seat_id} 预约成功", response.url, booking=booking)
         body_text = ""
         try:
             body_text = lxml_html.fromstring(response.text).text_content()
@@ -160,6 +174,17 @@ class Library:
         if auto_swap and any(token in body_text for token in ("已有预约", "已预约", "换座", "已经预约", "存在预约")):
             return self.swap_seat(seat_id, area_code)
         return BookResult(False, self._failure_reason(body_text), response.url)
+
+    def _is_my_page(self, url: str) -> bool:
+        candidates = [url]
+        try:
+            from auth import getOrdinaryUrl
+            ordinary = getOrdinaryUrl(url)
+            if ordinary:
+                candidates.append(ordinary)
+        except Exception:
+            pass
+        return any("/my/" in item or "/seat/my" in item for item in candidates)
 
     def _preflight(self, path: str) -> None:
         self._get(f"{BASE_URL}/my/")
@@ -187,27 +212,55 @@ class Library:
         booking = self.get_my_booking()
         booked = booking.seat_id if booking else ""
         if booked and (booked.lower() == seat_id.lower() or seat_id in booked or booked in seat_id):
-            return BookResult(True, f"已换座到 {booked}", response.url)
+            return BookResult(True, f"已换座到 {booked}", response.url, booking=booking)
         return BookResult(False, f"换座未生效{f'（当前仍为 {booked}）' if booked else ''}", response.url)
 
     def get_my_booking(self) -> MyBooking | None:
         for url in (f"{BASE_URL}/my/", f"{BASE_URL}/seat/my/", f"{BASE_URL}/seat/my"):
             response = self._get(url, timeout=12)
+            logger.info("get_my_booking: try %s -> %s len=%s", url, response.url, len(response.text))
             if len(response.text) < 50 or self._is_login_page(response.text, response.url):
+                logger.info("get_my_booking: skip login/empty page")
                 continue
-            try:
-                tree = lxml_html.fromstring(response.text)
-                body_text = tree.text_content()
-            except Exception:
-                continue
-            if "Not Found" in body_text and len(body_text) < 800:
-                continue
-            if any(token in body_text for token in ("暂无预约", "没有预约", "无预约", "暂无")) and not SEAT_ID_RE.search(body_text):
-                return None
-            booking = self._parse_booking(response.text, body_text)
+            booking = self._booking_from_html(response.text, response.url)
             if booking:
                 return booking
+        logger.info("get_my_booking: no active booking")
         return None
+
+    def _booking_from_html(self, html: str, url: str = "") -> MyBooking | None:
+        try:
+            tree = lxml_html.fromstring(html)
+            body_text = tree.text_content()
+        except Exception:
+            body_text = html
+        if "Not Found" in body_text and len(body_text) < 800:
+            return None
+        if any(token in body_text for token in ("暂无预约", "没有预约", "无预约")) and not SEAT_ID_RE.search(body_text):
+            return None
+        booking = self._parse_booking(html, body_text)
+        if booking is None or not booking.action_urls:
+            self._dump_booking_html(html, url)
+        if booking:
+            logger.info(
+                "get_my_booking: seat=%s area=%s status=%s actions=%s confirm=%s links=%s",
+                booking.seat_id, booking.area, booking.status_text,
+                list(booking.action_urls), len(CONFIRM_RE.findall(html)),
+                self._link_texts(html),
+            )
+        return booking
+
+    def _dump_booking_html(self, html: str, url: str) -> None:
+        logger.info("get_my_booking: empty actions url=%s html_prefix=%s", url, html[:400].replace("\n", " "))
+        try:
+            from app.utils.migrate_data import LOG_DIRECTORY
+            path = os.path.join(LOG_DIRECTORY, "library-booking.html")
+            with open(path, "w", encoding="utf-8") as handle:
+                handle.write(f"<!-- {url} -->\n")
+                handle.write(html)
+            logger.info("get_my_booking: dumped html to %s (%s bytes)", path, len(html))
+        except Exception as exc:
+            logger.info("get_my_booking: dump failed: %s", exc)
 
     def _parse_booking(self, html: str, body_text: str) -> MyBooking | None:
         status_matches = list(re.finditer(r"预约状态[:：]\s*(\S+)", body_text))
@@ -232,13 +285,57 @@ class Library:
             return MyBooking(seats[-1].group(0), area, status, action_urls)
         return None
 
+    def _link_texts(self, html: str) -> list[str]:
+        try:
+            tree = lxml_html.fromstring(html)
+        except Exception:
+            return []
+        texts = []
+        for element in tree.xpath(".//a | .//button | .//input[@type='submit']"):
+            text = (element.text_content() or element.get("value") or "").strip()
+            if text:
+                texts.append(text[:20])
+        return texts[:40]
+
     def _parse_actions(self, html: str) -> dict[str, str]:
-        actions = {}
+        actions: dict[str, str] = {}
         for action, reserve_id in CONFIRM_RE.findall(html):
             url = self._action_url(action, reserve_id)
             label = self._action_label(action)
             if url and label:
                 actions[label] = url
+            elif not label:
+                logger.info("get_my_booking: unknown confirm action=%s ri=%s", action, reserve_id)
+        try:
+            tree = lxml_html.fromstring(html)
+        except Exception:
+            tree = None
+        if tree is not None:
+            for element in tree.xpath(".//a[@href or @onclick or @data-href or @data-url] | .//button[@onclick]"):
+                text = (element.text_content() or "").strip()
+                label = self._label_from_text(text)
+                if not label or label in actions:
+                    continue
+                url = (
+                    element.get("data-href")
+                    or element.get("data-url")
+                    or element.get("data-action")
+                    or self._url_from_onclick(element.get("onclick") or "")
+                )
+                href = element.get("href") or ""
+                if not url and href and href not in {"#", "javascript:void(0)"} and "javascript:" not in href:
+                    url = href if href.startswith("http") else f"{BASE_URL}{href}"
+                if url:
+                    actions[label] = url if url.startswith("http") else f"{BASE_URL}{url}"
+            for form in tree.xpath(".//form[@action]"):
+                submit = form.xpath(".//button[@type='submit'] | .//input[@type='submit']")
+                text = ""
+                if submit:
+                    text = (submit[0].text_content() or submit[0].get("value") or "").strip()
+                label = self._label_from_text(text)
+                action = form.get("action") or ""
+                if label and label not in actions and action and action != "#":
+                    actions[label] = action if action.startswith("http") else f"{BASE_URL}{action}"
         if "取消预约" in actions:
             return actions
         for match in re.finditer(
@@ -250,6 +347,33 @@ class Library:
             if label and label not in actions:
                 actions[label] = f"{BASE_URL}{prefix}{reserve_id}"
         return actions
+
+    def _url_from_onclick(self, onclick: str) -> str:
+        match = CONFIRM_RE.search(onclick)
+        if match:
+            return self._action_url(match.group(1), match.group(2))
+        href = re.search(r"""(?:location\.href|location|window\.location)\s*=\s*['"]([^'"]+)['"]""", onclick)
+        if href:
+            url = href.group(1)
+            return url if url.startswith("http") else f"{BASE_URL}{url}"
+        path = re.search(r"""['"](/[^'"]+)['"]""", onclick)
+        if path:
+            url = path.group(1)
+            return url if url.startswith("http") else f"{BASE_URL}{url}"
+        return ""
+
+    def _label_from_text(self, text: str) -> str:
+        if "取消" in text and "预约" in text:
+            return "取消预约"
+        if "线上签到" in text or (("入馆" in text or "签到" in text) and "离" not in text and "返" not in text):
+            return "入馆签到"
+        if "中途离开" in text or "暂离" in text or "离馆" in text:
+            return "中途离开"
+        if "中途返回" in text or "回馆" in text:
+            return "中途返回"
+        if "取消" in text:
+            return "取消预约"
+        return ""
 
     def _action_label(self, action: str) -> str:
         text = action.lower()

--- a/library/seats.py
+++ b/library/seats.py
@@ -1,0 +1,295 @@
+from __future__ import annotations
+
+import json
+import re
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+import requests
+from lxml import html as lxml_html
+
+from auth.constant import MOBILE_BROWSER_UA
+
+
+BASE_URL = "http://rg.lib.xjtu.edu.cn:8086"
+SEAT_ID_RE = re.compile(r"(?:[A-Z]\d{2,4}|\b\d{3}\b)")
+CONFIRM_RE = re.compile(r"showConfirmModal\s*\(\s*['\"][^'\"]*['\"]\s*,\s*'(\w+)'\s*,\s*'(\d+)'\s*\)")
+MOBILE_UA = MOBILE_BROWSER_UA
+MOBILE_ONLY_HINT = "移动端模式"
+
+AREA_MAP = {
+    "北楼二层外文库（东）": "north2east",
+    "二层连廊及流通大厅": "north2elian",
+    "北楼二层外文库（西）": "north2west",
+    "南楼二层大厅": "south2",
+    "北楼三层ILibrary-B（西）": "west3B",
+    "大屏辅学空间": "eastnorthda",
+    "南楼三层中段": "south3middle",
+    "北楼三层ILibrary-A（东）": "east3A",
+    "北楼四层西侧": "north4west",
+    "北楼四层中间": "north4middle",
+    "北楼四层东侧": "north4east",
+    "北楼四层西南侧": "north4southwest",
+    "北楼四层东南侧": "north4southeast",
+}
+AREA_MAP_REVERSE = {code: name for name, code in AREA_MAP.items()}
+FLOORS = {
+    "二楼": ["北楼二层外文库（东）", "二层连廊及流通大厅", "北楼二层外文库（西）", "南楼二层大厅"],
+    "三楼": ["北楼三层ILibrary-B（西）", "大屏辅学空间", "南楼三层中段", "北楼三层ILibrary-A（东）"],
+    "四楼": ["北楼四层西侧", "北楼四层中间", "北楼四层东侧", "北楼四层西南侧", "北楼四层东南侧"],
+}
+FLOOR_CODES = {"二楼": "xingqing2floor", "三楼": "xingqing3floor", "四楼": "xingqing4floor"}
+AREA_FLOOR_CODES = {
+    AREA_MAP[area]: FLOOR_CODES[floor]
+    for floor, areas in FLOORS.items()
+    for area in areas
+    if area in AREA_MAP
+}
+INACTIVE_STATUSES = {"已取消", "已完成", "已过期", "已失效", "已违约", "超时取消", "超时未入馆", "超时", "已离馆"}
+
+
+@dataclass
+class SeatInfo:
+    seat_id: str
+    available: bool
+
+
+@dataclass
+class AreaStats:
+    available: int
+    total: int
+
+
+@dataclass
+class BookResult:
+    success: bool
+    message: str
+    final_url: str = ""
+
+
+@dataclass
+class MyBooking:
+    seat_id: str
+    area: str
+    status_text: str
+    action_urls: dict[str, str] = field(default_factory=dict)
+
+
+class Library:
+    def __init__(self, session: requests.Session):
+        self.session = session
+        self.area_stats: dict[str, AreaStats] = {}
+
+    def _headers(self, referer: str = f"{BASE_URL}/seat/", ajax: bool = False) -> dict[str, str]:
+        headers = {"User-Agent": MOBILE_UA, "Referer": referer}
+        if ajax:
+            headers["X-Requested-With"] = "XMLHttpRequest"
+            headers["Accept"] = "application/json, text/javascript, */*; q=0.01"
+        return headers
+
+    def _get(self, url: str, referer: str = f"{BASE_URL}/seat/", ajax: bool = False, timeout: int = 15) -> requests.Response:
+        response = self.session.get(url, headers=self._headers(referer, ajax), timeout=timeout)
+        if MOBILE_ONLY_HINT in response.text:
+            raise RuntimeError("请浏览器调成移动端模式访问！")
+        return response
+
+    def _looks_like_json(self, body: str) -> bool:
+        stripped = body.lstrip()
+        return stripped.startswith("{") or stripped.startswith("[")
+
+    def _is_login_page(self, body: str, url: str) -> bool:
+        return (
+            'id="loginForm"' in body
+            or 'name="execution"' in body
+            or "cas/login" in body
+            or "login.xjtu.edu.cn" in url
+        )
+
+    def _parse_json(self, body: str) -> dict[str, Any]:
+        if not self._looks_like_json(body):
+            raise RuntimeError("图书馆接口返回异常（非 JSON 响应）")
+        return json.loads(body)
+
+    def _parse_stats(self, scount: dict | None) -> dict[str, AreaStats]:
+        result = {}
+        for key, value in (scount or {}).items():
+            if key not in AREA_MAP.values() or not isinstance(value, list) or len(value) < 2:
+                continue
+            result[key] = AreaStats(available=int(value[1]), total=int(value[0]))
+        return result
+
+    def _load_floor(self, area_code: str) -> None:
+        floor_code = AREA_FLOOR_CODES.get(area_code)
+        if not floor_code:
+            return
+        response = self._get(f"{BASE_URL}/qspace?lang=zh&floor={floor_code}", ajax=True)
+        payload = self._parse_json(response.text)
+        self.area_stats = self._parse_stats(payload.get("scount"))
+
+    def get_seats(self, area_code: str) -> tuple[list[SeatInfo], dict[str, AreaStats]]:
+        self._load_floor(area_code)
+        floor_code = AREA_FLOOR_CODES.get(area_code)
+        referer = f"{BASE_URL}/qspace?lang=zh&floor={floor_code}" if floor_code else f"{BASE_URL}/seat/"
+        response = self._get(f"{BASE_URL}/qseat?sp={area_code}", referer=referer, ajax=True)
+        if self._is_login_page(response.text, response.url):
+            raise RuntimeError("图书馆登录态已失效")
+        payload = self._parse_json(response.text)
+        stats = self._parse_stats(payload.get("scount"))
+        if stats:
+            self.area_stats = stats
+        seats = [
+            SeatInfo(seat_id=seat_id, available=status == 0)
+            for seat_id, status in (payload.get("seat") or {}).items()
+        ]
+        seats.sort(key=lambda item: (item.seat_id[:1], item.seat_id))
+        return seats, self.area_stats
+
+    def book_seat(self, seat_id: str, area_code: str, auto_swap: bool = True) -> BookResult:
+        response = self._get(f"{BASE_URL}/seat/?kid={seat_id}&sp={area_code}")
+        if "/my/" in response.url or "/seat/my/" in response.url:
+            return BookResult(True, f"座位 {seat_id} 预约成功", response.url)
+        body_text = ""
+        try:
+            body_text = lxml_html.fromstring(response.text).text_content()
+        except Exception:
+            body_text = response.text
+        if auto_swap and any(token in body_text for token in ("已有预约", "已预约", "换座", "已经预约", "存在预约")):
+            return self.swap_seat(seat_id, area_code)
+        return BookResult(False, self._failure_reason(body_text), response.url)
+
+    def _preflight(self, path: str) -> None:
+        self._get(f"{BASE_URL}/my/")
+        if path != "/my/":
+            self._get(f"{BASE_URL}{path}")
+        access_mode = getattr(self.session, "access_mode", None)
+        if access_mode is not None and getattr(access_mode, "value", "") == "webvpn":
+            cookie_url = (
+                "https://webvpn.xjtu.edu.cn/wengine-vpn/cookie"
+                f"?method=get&host=rg.lib.xjtu.edu.cn&scheme=http&path={path}"
+                f"&vpn_timestamp={int(time.time() * 1000)}"
+            )
+            self.session.get(cookie_url, timeout=10, _skip_webvpn_rewrite=True)
+
+    def swap_seat(self, seat_id: str, area_code: str) -> BookResult:
+        self._preflight("/updateseat/")
+        try:
+            self._get(f"{BASE_URL}/qseat?sp={area_code}", referer=f"{BASE_URL}/updateseat/", ajax=True)
+        except Exception:
+            pass
+        response = self._get(
+            f"{BASE_URL}/updateseat/?kid={seat_id}&sp={area_code}",
+            referer=f"{BASE_URL}/updateseat/",
+        )
+        booking = self.get_my_booking()
+        booked = booking.seat_id if booking else ""
+        if booked and (booked.lower() == seat_id.lower() or seat_id in booked or booked in seat_id):
+            return BookResult(True, f"已换座到 {booked}", response.url)
+        return BookResult(False, f"换座未生效{f'（当前仍为 {booked}）' if booked else ''}", response.url)
+
+    def get_my_booking(self) -> MyBooking | None:
+        for url in (f"{BASE_URL}/my/", f"{BASE_URL}/seat/my/", f"{BASE_URL}/seat/my"):
+            response = self._get(url, timeout=12)
+            if len(response.text) < 50 or self._is_login_page(response.text, response.url):
+                continue
+            try:
+                tree = lxml_html.fromstring(response.text)
+                body_text = tree.text_content()
+            except Exception:
+                continue
+            if "Not Found" in body_text and len(body_text) < 800:
+                continue
+            if any(token in body_text for token in ("暂无预约", "没有预约", "无预约", "暂无")) and not SEAT_ID_RE.search(body_text):
+                return None
+            booking = self._parse_booking(response.text, body_text)
+            if booking:
+                return booking
+        return None
+
+    def _parse_booking(self, html: str, body_text: str) -> MyBooking | None:
+        status_matches = list(re.finditer(r"预约状态[:：]\s*(\S+)", body_text))
+        action_urls = self._parse_actions(html)
+        if not status_matches:
+            seat = SEAT_ID_RE.search(body_text)
+            if not seat:
+                return None
+            area = next((name for name in AREA_MAP if name in body_text), "")
+            return MyBooking(seat.group(0), area, "", action_urls)
+        start = 0
+        for match in status_matches:
+            status = match.group(1)
+            block = body_text[start:match.end()]
+            start = match.end()
+            if status in INACTIVE_STATUSES:
+                continue
+            seats = list(SEAT_ID_RE.finditer(block))
+            if not seats:
+                continue
+            area = next((name for name in AREA_MAP if name in block), "")
+            return MyBooking(seats[-1].group(0), area, status, action_urls)
+        return None
+
+    def _parse_actions(self, html: str) -> dict[str, str]:
+        actions = {}
+        for action, reserve_id in CONFIRM_RE.findall(html):
+            url = self._action_url(action, reserve_id)
+            label = self._action_label(action)
+            if url and label:
+                actions[label] = url
+        if "取消预约" in actions:
+            return actions
+        for match in re.finditer(
+            r"""['"](/my/\?(?:cancel|firstruguan|midleave|midreturn)=1&ri=)(\d+)['"]""",
+            html,
+        ):
+            prefix, reserve_id = match.groups()
+            label = self._action_label(prefix)
+            if label and label not in actions:
+                actions[label] = f"{BASE_URL}{prefix}{reserve_id}"
+        return actions
+
+    def _action_label(self, action: str) -> str:
+        text = action.lower()
+        if "cancel" in text:
+            return "取消预约"
+        if "ruguan" in text or "firstruguan" in text:
+            return "入馆签到"
+        if "leave" in text:
+            return "中途离开"
+        if "return" in text:
+            return "中途返回"
+        return ""
+
+    def _action_url(self, action: str, reserve_id: str) -> str:
+        mapping = {
+            "cancel": f"{BASE_URL}/my/?cancel=1&ri={reserve_id}",
+            "ruguan1": f"{BASE_URL}/my/?firstruguan=1&ri={reserve_id}",
+            "leave": f"{BASE_URL}/my/?midleave=1&ri={reserve_id}",
+            "midleave": f"{BASE_URL}/my/?midleave=1&ri={reserve_id}",
+            "return": f"{BASE_URL}/my/?midreturn=1&ri={reserve_id}",
+            "midreturn": f"{BASE_URL}/my/?midreturn=1&ri={reserve_id}",
+        }
+        return mapping.get(action, "")
+
+    def execute_action(self, url: str) -> BookResult:
+        self._preflight("/my/")
+        response = self._get(url, referer=f"{BASE_URL}/my/")
+        if "cancel=1" in url:
+            booking = self.get_my_booking()
+            if booking is None:
+                return BookResult(True, "已取消预约", response.url)
+            return BookResult(False, f"取消未生效，当前仍为 {booking.seat_id}", response.url)
+        return BookResult(True, "操作已提交", response.url)
+
+    def _failure_reason(self, body_text: str) -> str:
+        if "30分钟" in body_text:
+            return "30 分钟内不能重复预约"
+        if "已被预约" in body_text or "已被占" in body_text:
+            return "该座位已被他人预约"
+        if "已有预约" in body_text or "已预约" in body_text:
+            return "您已有其他座位预约"
+        if "不在预约时间" in body_text or "未开放" in body_text:
+            return "当前不在预约开放时间"
+        if "维护" in body_text:
+            return "系统维护中"
+        return "预约失败"

--- a/library/seats.py
+++ b/library/seats.py
@@ -109,7 +109,10 @@ class Library:
     def _parse_json(self, body: str) -> dict[str, Any]:
         if not self._looks_like_json(body):
             raise RuntimeError("图书馆接口返回异常（非 JSON 响应）")
-        return json.loads(body)
+        try:
+            return json.loads(body)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError("图书馆接口返回了无法解析的数据") from exc
 
     def _parse_stats(self, scount: dict | None) -> dict[str, AreaStats]:
         result = {}

--- a/test/app/test_campus_job.py
+++ b/test/app/test_campus_job.py
@@ -1,0 +1,90 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from app.utils.campus_job import JOB_FAILED, run_campus_job
+
+
+def _thread():
+    thread = SimpleNamespace(can_run=True)
+    thread.tr = lambda text: text
+    thread.error = Mock()
+    thread.canceled = Mock()
+    thread.setIndeterminate = Mock()
+    thread.messageChanged = Mock()
+    return thread
+
+
+class CampusJobTest(unittest.TestCase):
+    def test_missing_account_is_failure_not_none(self):
+        thread = _thread()
+        with patch("app.utils.campus_job.accounts") as accounts:
+            accounts.current = None
+            result = run_campus_job(
+                thread,
+                site_key="hello",
+                login_message="login",
+                worker=lambda session: None,
+            )
+        self.assertIs(result, JOB_FAILED)
+        self.assertFalse(thread.can_run)
+        thread.canceled.emit.assert_called_once()
+
+    def test_worker_none_is_success(self):
+        account = SimpleNamespace(
+            username="u",
+            password="p",
+            session_manager=SimpleNamespace(
+                get_session=lambda key: SimpleNamespace(
+                    ensure_login=lambda *args, **kwargs: None,
+                ),
+                mfa_provider=None,
+            ),
+        )
+        thread = _thread()
+        with patch("app.utils.campus_job.accounts") as accounts:
+            accounts.current = account
+            result = run_campus_job(
+                thread,
+                site_key="library",
+                login_message="login",
+                worker=lambda session: None,
+            )
+        self.assertIsNone(result)
+        self.assertTrue(thread.can_run)
+
+    def test_uses_account_snapshot_after_switch(self):
+        session = SimpleNamespace(seen=None)
+
+        def ensure_login(username, password, account=None, mfa_provider=None):
+            session.seen = (username, password, account)
+
+        first = SimpleNamespace(
+            username="a",
+            password="ap",
+            session_manager=SimpleNamespace(
+                get_session=lambda key: SimpleNamespace(ensure_login=ensure_login),
+                mfa_provider="mfa-a",
+            ),
+        )
+        second = SimpleNamespace(username="b", password="bp")
+        holder = SimpleNamespace(current=first)
+        thread = _thread()
+
+        def worker(_session):
+            holder.current = second
+            return "ok"
+
+        with patch("app.utils.campus_job.accounts", holder):
+            result = run_campus_job(
+                thread,
+                site_key="hello",
+                login_message="login",
+                worker=worker,
+            )
+        self.assertEqual(result, "ok")
+        self.assertEqual(session.seen, ("a", "ap", first))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/app/test_http_headers.py
+++ b/test/app/test_http_headers.py
@@ -1,0 +1,19 @@
+import unittest
+
+from app.sessions.common_session import http_safe_headers
+
+
+class HttpSafeHeadersTest(unittest.TestCase):
+    def test_drops_non_latin1_values(self):
+        safe = http_safe_headers({
+            "User-Agent": "Mozilla/5.0",
+            "X-Card-Name": "张三",
+            "Referer": "http://rg.lib.xjtu.edu.cn:8086/seat/",
+        })
+        self.assertEqual(safe["User-Agent"], "Mozilla/5.0")
+        self.assertEqual(safe["Referer"], "http://rg.lib.xjtu.edu.cn:8086/seat/")
+        self.assertNotIn("X-Card-Name", safe)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/library/test_booking_parse.py
+++ b/test/library/test_booking_parse.py
@@ -45,6 +45,33 @@ class LibraryBookingParseTest(unittest.TestCase):
         self.assertEqual(booking.status_text, "使用中")
         self.assertIn("中途离开", booking.action_urls)
 
+    def test_actions_from_button_onclick(self):
+        body = "北楼二层外文库（东） A101 预约状态：已预约"
+        html = """
+        <div>北楼二层外文库（东） A101 预约状态：已预约</div>
+        <button onclick="showConfirmModal('确认取消','cancel','77')">取消预约</button>
+        <a href="#" onclick="showConfirmModal('确认','ruguan1','77')">入馆签到</a>
+        """
+        booking = self.library._parse_booking(html, body)
+        self.assertIsNotNone(booking)
+        self.assertIn("取消预约", booking.action_urls)
+        self.assertIn("入馆签到", booking.action_urls)
+        self.assertIn("ri=77", booking.action_urls["取消预约"])
+
+    def test_actions_from_form_and_double_quotes(self):
+        body = "北楼二层外文库（东） A101 预约状态：已预约"
+        html = """
+        <div>北楼二层外文库（东） A101 预约状态：已预约</div>
+        <script>showConfirmModal("确认","cancel","66")</script>
+        <form action="/my/?firstruguan=1&ri=66">
+            <input type="submit" value="入馆签到">
+        </form>
+        """
+        booking = self.library._parse_booking(html, body)
+        self.assertIsNotNone(booking)
+        self.assertIn("取消预约", booking.action_urls)
+        self.assertIn("入馆签到", booking.action_urls)
+
     def test_invalid_json_has_stable_error(self):
         with self.assertRaises(RuntimeError) as ctx:
             self.library._parse_json("{not json")

--- a/test/library/test_booking_parse.py
+++ b/test/library/test_booking_parse.py
@@ -1,0 +1,55 @@
+import unittest
+from types import SimpleNamespace
+
+from library.seats import Library
+
+
+class LibraryBookingParseTest(unittest.TestCase):
+    def setUp(self):
+        self.library = Library(SimpleNamespace())
+
+    def test_no_booking(self):
+        html = "<div>暂无预约</div>"
+        self.assertIsNone(self.library._parse_booking(html, "暂无预约"))
+
+    def test_active_booking_and_actions(self):
+        body = "北楼二层外文库（东） 座位 A101 预约状态：已预约"
+        html = """
+        <div>北楼二层外文库（东） A101 预约状态：已预约</div>
+        <script>showConfirmModal('确认','cancel','88')</script>
+        <script>showConfirmModal('确认','ruguan1','88')</script>
+        """
+        booking = self.library._parse_booking(html, body)
+        self.assertIsNotNone(booking)
+        self.assertEqual(booking.seat_id, "A101")
+        self.assertEqual(booking.area, "北楼二层外文库（东）")
+        self.assertEqual(booking.status_text, "已预约")
+        self.assertIn("取消预约", booking.action_urls)
+        self.assertIn("入馆签到", booking.action_urls)
+
+    def test_canceled_booking_is_ignored(self):
+        body = "A101 预约状态：已取消"
+        html = "<div>A101 预约状态：已取消</div>"
+        self.assertIsNone(self.library._parse_booking(html, body))
+
+    def test_multiple_statuses_picks_active(self):
+        body = "A101 预约状态：已取消 B202 预约状态：使用中"
+        html = """
+        <div>A101 预约状态：已取消</div>
+        <div>B202 预约状态：使用中</div>
+        <script>showConfirmModal('确认','leave','9')</script>
+        """
+        booking = self.library._parse_booking(html, body)
+        self.assertIsNotNone(booking)
+        self.assertEqual(booking.seat_id, "B202")
+        self.assertEqual(booking.status_text, "使用中")
+        self.assertIn("中途离开", booking.action_urls)
+
+    def test_invalid_json_has_stable_error(self):
+        with self.assertRaises(RuntimeError) as ctx:
+            self.library._parse_json("{not json")
+        self.assertIn("无法解析", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- 侧栏增加图书馆：分区空座、预约、换座、取消、入馆签到、中途离开 / 返回。
- 座位系统校验移动端 UA，会话层覆盖桌面 Chrome，避免被接口直接拒绝。

## Test plan
- [x] 登录后能看到分区空座
- [x] 预约 / 换座 / 取消可走通
- [x] 入馆签到与中途离开 / 返回可用
- [x] 校外 WebVPN 下仍能打开座位页
