### PR TITLE
fix(search): 收紧可用搜索来源

### DIFF
--- a/ai_assistant/__init__.py
+++ b/ai_assistant/__init__.py
@@ -21,6 +21,7 @@ from .conversations import (
 )
 from .web_search import (
     SEARCH_ENGINES,
+    SearchAllSourcesVerificationRequired,
     SearchHumanVerificationRequired,
     SearchResult,
     WebSearchClient,
@@ -47,6 +48,7 @@ __all__ = [
     "ProviderPreset",
     "SecretPersistence",
     "SEARCH_ENGINES",
+    "SearchAllSourcesVerificationRequired",
     "SearchResult",
     "SearchHumanVerificationRequired",
     "ToolCall",

--- a/ai_assistant/config.py
+++ b/ai_assistant/config.py
@@ -27,10 +27,10 @@ from .providers import (
     preset_for,
 )
 from .capabilities import validate_capability_ids
-from .web_search import DUCKDUCKGO_ENDPOINT, validate_search_settings
+from .web_search import DISABLED_SEARCH_ENGINES, validate_search_settings
 
 
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 4
 KEYRING_SERVICE = "XJTUToolbox.AI"
 DEFAULT_ASSISTANT_NAME = "问舟"
 DEFAULT_SYSTEM_PROMPT = "你是仙交百宝箱中的 AI 助手问舟。请准确、坦诚地回答，不确定时明确说明。"
@@ -55,8 +55,8 @@ class AIProfile:
     max_output_tokens: int = 2048
     temperature: float = 0.7
     capability_ids: tuple[str, ...] = ()
-    search_engine: str = "duckduckgo"
-    search_endpoint: str = DUCKDUCKGO_ENDPOINT
+    search_engine: str = "auto"
+    search_endpoint: str = ""
     search_result_limit: int = 5
 
     @classmethod
@@ -136,10 +136,11 @@ class AIConfigStore:
         self.last_error = ""
         try:
             payload = json.loads(self.path.read_text(encoding="utf-8"))
-            if payload.get("version") not in {1, SCHEMA_VERSION}:
+            version = payload.get("version")
+            if version not in {1, 2, 3, SCHEMA_VERSION}:
                 raise ValueError("不支持的 AI 配置版本")
             profiles = [
-                validate_profile(self._migrate_legacy_branding(AIProfile(**one)))
+                validate_profile(self._profile_from_payload(one, version))
                 for one in payload.get("profiles", [])
             ]
             if not profiles:
@@ -224,6 +225,15 @@ class AIConfigStore:
         ):
             updates["model"] = preset_for("deepseek").default_model
         return replace(profile, **updates) if updates else profile
+
+    @classmethod
+    def _profile_from_payload(cls, data: dict, version: int) -> AIProfile:
+        profile = cls._migrate_legacy_branding(AIProfile(**data))
+        if version < 3 and profile.search_engine != "auto":
+            profile = replace(profile, search_engine="auto", search_endpoint="")
+        elif version < 4 and profile.search_engine in DISABLED_SEARCH_ENGINES:
+            profile = replace(profile, search_engine="auto", search_endpoint="")
+        return profile
 
     @staticmethod
     def new_profile(preset_id: str = "deepseek", name: str = DEFAULT_ASSISTANT_NAME) -> AIProfile:

--- a/ai_assistant/web_search.py
+++ b/ai_assistant/web_search.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from base64 import urlsafe_b64decode
+from binascii import Error as BinasciiError
 from dataclasses import dataclass
 import json
 from urllib.parse import parse_qs, unquote, urljoin, urlparse
@@ -10,19 +12,44 @@ import requests
 from lxml import html
 
 
+BAIDU_ENDPOINT = "https://www.baidu.com/s"
+BING_ENDPOINT = "https://www.bing.com/search"
+GOOGLE_ENDPOINT = "https://www.google.com.hk/search"
+SOGOU_ENDPOINT = "https://m.sogou.com/web/searchList.jsp"
+SO360_ENDPOINT = "https://www.so.com/s"
+SHENMA_ENDPOINT = "https://m.sm.cn/s"
 DUCKDUCKGO_ENDPOINT = "https://html.duckduckgo.com/html/"
 SEARCH_ENGINES = (
-    ("duckduckgo", "DuckDuckGo（内置）"),
-    ("bing", "Bing（通过 SearXNG）"),
-    ("baidu", "百度（通过 SearXNG）"),
-    ("google", "Google（通过 SearXNG）"),
-    ("searxng", "SearXNG（聚合）"),
+    ("auto", "自动（直连推荐）"),
+    ("bing", "Bing（直连）"),
+    ("sogou", "搜狗（直连）"),
+    ("so360", "360 搜索（直连）"),
 )
-SEARXNG_ENGINES = {"bing", "baidu", "google", "searxng"}
+BUILTIN_ENGINES = {engine for engine, _label in SEARCH_ENGINES}
+DISABLED_SEARCH_ENGINES = {
+    "baidu",
+    "google",
+    "shenma",
+    "duckduckgo",
+    "searxng",
+}
+
+_BROWSER_HEADERS = {
+    "Accept-Language": "zh-CN,zh;q=0.9,en;q=0.7",
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/131.0.0.0 Safari/537.36"
+    ),
+}
 
 
 class SearchHumanVerificationRequired(RuntimeError):
     """The public search endpoint returned a CAPTCHA/challenge page."""
+
+
+class SearchAllSourcesVerificationRequired(SearchHumanVerificationRequired):
+    """Every source in automatic mode returned a CAPTCHA/challenge page."""
 
 
 @dataclass(frozen=True)
@@ -32,11 +59,17 @@ class SearchResult:
     snippet: str = ""
 
 
-def validate_search_settings(engine: str, endpoint: str) -> tuple[str, str]:
+def validate_search_settings(engine: str, endpoint: str = "") -> tuple[str, str]:
     engine = str(engine).strip().lower()
-    if engine not in {one[0] for one in SEARCH_ENGINES}:
-        raise ValueError("不支持的联网搜索引擎")
-    endpoint = DUCKDUCKGO_ENDPOINT if engine == "duckduckgo" else str(endpoint).strip()
+    if engine in BUILTIN_ENGINES:
+        return engine, ""
+    if engine in DISABLED_SEARCH_ENGINES:
+        raise ValueError("该联网搜索引擎暂不可用")
+    raise ValueError("不支持的联网搜索引擎")
+
+
+def _validate_searxng_endpoint(endpoint: str) -> str:
+    endpoint = str(endpoint).strip()
     parsed = urlparse(endpoint)
     if parsed.scheme not in {"http", "https"} or not parsed.netloc:
         raise ValueError("搜索地址必须是完整的 HTTP(S) URL")
@@ -44,7 +77,7 @@ def validate_search_settings(engine: str, endpoint: str) -> tuple[str, str]:
         raise ValueError("搜索地址不得包含凭据、查询参数或片段")
     if parsed.scheme == "http" and parsed.hostname not in {"127.0.0.1", "localhost", "::1"}:
         raise ValueError("非本机搜索服务必须使用 HTTPS")
-    return engine, endpoint.rstrip("/") + ("/" if parsed.path in {"", "/"} else "")
+    return endpoint.rstrip("/") + ("/" if parsed.path in {"", "/"} else "")
 
 
 class WebSearchClient:
@@ -52,32 +85,188 @@ class WebSearchClient:
         self.session = session or requests.Session()
         self.timeout = timeout
 
-    def search(self, query: str, *, engine: str, endpoint: str, limit: int = 5) -> list[SearchResult]:
+    def search(
+        self,
+        query: str,
+        *,
+        engine: str,
+        endpoint: str = "",
+        limit: int = 5,
+    ) -> list[SearchResult]:
         query = " ".join(str(query).split())
         if not query or len(query) > 500:
             raise ValueError("搜索词长度必须在 1–500 字符之间")
         if not 1 <= int(limit) <= 10:
             raise ValueError("搜索结果数量必须在 1–10 之间")
         engine, endpoint = validate_search_settings(engine, endpoint)
-        params = {"q": query}
-        if engine in SEARXNG_ENGINES:
-            params["format"] = "json"
-            if engine != "searxng":
-                params["engines"] = engine
+        if engine == "auto":
+            return self._search_auto(query, int(limit))
+        return self._search_one(query, engine, endpoint, int(limit))
+
+    def _search_auto(self, query: str, limit: int) -> list[SearchResult]:
+        challenges = 0
+        for engine in ("bing", "sogou", "so360"):
+            try:
+                results = self._search_one(query, engine, "", limit)
+            except SearchHumanVerificationRequired:
+                challenges += 1
+            except RuntimeError:
+                continue
+            else:
+                if results:
+                    return results
+        if challenges == 3:
+            raise SearchAllSourcesVerificationRequired(
+                "自动模式的公开搜索服务均要求人机验证；已自动关闭联网搜索"
+            )
+        raise RuntimeError("内置联网搜索暂时不可用，请稍后重试")
+
+    def _search_one(
+        self,
+        query: str,
+        engine: str,
+        endpoint: str,
+        limit: int,
+    ) -> list[SearchResult]:
+        if engine == "duckduckgo":
+            content, encoding = self._fetch(
+                DUCKDUCKGO_ENDPOINT,
+                params={"q": query},
+                accept="text/html,application/xhtml+xml",
+            )
+            results = self._parse_duckduckgo(content.decode(encoding, errors="replace"))
+        elif engine == "bing":
+            content, encoding = self._fetch(
+                BING_ENDPOINT,
+                params={"q": query, "setlang": "zh-Hans"},
+                accept="text/html,application/xhtml+xml",
+            )
+            results = self._parse_bing(content.decode(encoding, errors="replace"))
+        elif engine == "baidu":
+            content, encoding = self._fetch(
+                BAIDU_ENDPOINT,
+                params={"wd": query},
+                accept="text/html,application/xhtml+xml",
+            )
+            results = self._parse_baidu(content.decode(encoding, errors="replace"))
+            return self._resolve_baidu_results(results, limit)
+        elif engine == "so360":
+            content, encoding = self._fetch(
+                SO360_ENDPOINT,
+                params={"q": query},
+                accept="text/html,application/xhtml+xml",
+            )
+            results = self._parse_so360(content.decode(encoding, errors="replace"))
+        elif engine == "sogou":
+            content, encoding = self._fetch(
+                SOGOU_ENDPOINT,
+                params={"keyword": query},
+                accept="text/html,application/xhtml+xml",
+            )
+            results = self._parse_sogou(content.decode(encoding, errors="replace"))
+        elif engine == "shenma":
+            content, encoding = self._fetch(
+                SHENMA_ENDPOINT,
+                params={"q": query},
+                accept="text/html,application/xhtml+xml",
+            )
+            results = self._parse_shenma(content.decode(encoding, errors="replace"))
+        elif engine == "google":
+            content, encoding = self._fetch(
+                GOOGLE_ENDPOINT,
+                params={"q": query},
+                accept="text/html,application/xhtml+xml",
+            )
+            results = self._parse_google(content.decode(encoding, errors="replace"))
+        else:
+            endpoint = _validate_searxng_endpoint(endpoint)
             if not endpoint.rstrip("/").endswith("/search"):
                 endpoint = endpoint.rstrip("/") + "/search"
+            content, _encoding = self._fetch(
+                endpoint,
+                params={"q": query, "format": "json"},
+                accept="application/json",
+            )
+            results = self._parse_searxng(content)
+        return results[:limit]
+
+    def _resolve_baidu_results(
+        self,
+        results: list[SearchResult],
+        limit: int,
+    ) -> list[SearchResult]:
+        resolved = []
+        for result in results[:limit]:
+            parsed = urlparse(result.url)
+            host = (parsed.hostname or "").lower()
+            if not (
+                (host == "baidu.com" or host.endswith(".baidu.com"))
+                and parsed.path.startswith("/link")
+            ):
+                resolved.extend(
+                    _normalize_results([(result.title, result.url, result.snippet)])
+                )
+                continue
+            response = None
+            try:
+                response = self.session.head(
+                    result.url,
+                    headers=_BROWSER_HEADERS,
+                    timeout=self.timeout,
+                    allow_redirects=False,
+                )
+                status = int(response.status_code)
+                location = (
+                    str(response.headers.get("Location", ""))
+                    if 300 <= status < 400
+                    else ""
+                )
+                resolved.extend(
+                    _normalize_results(
+                        [
+                            (
+                                result.title,
+                                urljoin(result.url, location) if location else "",
+                                result.snippet,
+                            )
+                        ]
+                    )
+                )
+            except requests.RequestException:
+                continue
+            finally:
+                if response is not None:
+                    response.close()
+        return resolved
+
+    def _fetch(
+        self,
+        endpoint: str,
+        *,
+        params: dict[str, str],
+        accept: str,
+    ) -> tuple[bytes, str]:
         response = None
         try:
+            headers = {**_BROWSER_HEADERS, "Accept": accept}
             response = self.session.get(
                 endpoint,
                 params=params,
-                headers={"Accept": "application/json" if engine in SEARXNG_ENGINES else "text/html"},
+                headers=headers,
                 timeout=self.timeout,
                 allow_redirects=False,
                 stream=True,
             )
             status = int(response.status_code)
+            if (
+                endpoint == SHENMA_ENDPOINT
+                and str(response.headers.get("bxpunish", "")).strip() not in {"", "0"}
+            ):
+                raise SearchHumanVerificationRequired("神马要求人机验证")
             if 300 <= status < 400:
+                location = str(response.headers.get("Location", "")).strip()
+                if _is_human_verification_redirect(endpoint, location):
+                    raise SearchHumanVerificationRequired("百度要求人机验证")
                 raise RuntimeError("联网搜索服务返回了重定向；请直接填写最终搜索地址")
             if not 200 <= status < 300:
                 raise RuntimeError(f"联网搜索失败（HTTP {status}）")
@@ -92,12 +281,7 @@ class WebSearchClient:
                 content.extend(chunk)
                 if len(content) > 2 * 1024 * 1024:
                     raise RuntimeError("联网搜索响应超过 2 MiB 安全上限")
-            if engine in SEARXNG_ENGINES:
-                results = self._parse_searxng(bytes(content))
-            else:
-                encoding = getattr(response, "encoding", None) or "utf-8"
-                results = self._parse_duckduckgo(bytes(content).decode(encoding, errors="replace"))
-            return results[: int(limit)]
+            return bytes(content), getattr(response, "encoding", None) or "utf-8"
         except requests.Timeout as error:
             raise RuntimeError("联网搜索超时") from error
         except requests.ConnectionError as error:
@@ -114,7 +298,13 @@ class WebSearchClient:
             payload = json.loads(content)
         except (TypeError, ValueError, UnicodeDecodeError) as error:
             raise RuntimeError("SearXNG 返回了无效 JSON") from error
-        rows = payload.get("results", []) if isinstance(payload, dict) else []
+        if (
+            not isinstance(payload, dict)
+            or "results" not in payload
+            or not isinstance(payload["results"], list)
+        ):
+            raise RuntimeError("SearXNG 返回了无效 JSON")
+        rows = payload["results"]
         return _normalize_results(
             (row.get("title"), row.get("url"), row.get("content"))
             for row in rows
@@ -123,14 +313,9 @@ class WebSearchClient:
 
     @staticmethod
     def _parse_duckduckgo(content: str) -> list[SearchResult]:
-        try:
-            document = html.fromstring(content)
-        except (TypeError, ValueError) as error:
-            raise RuntimeError("DuckDuckGo 返回了无法解析的页面") from error
+        document = _parse_html(content, "DuckDuckGo")
         if document.xpath("//*[@id='challenge-form' or contains(@class, 'anomaly-modal')]"):
-            raise SearchHumanVerificationRequired(
-                "DuckDuckGo 要求人机验证；已自动关闭联网搜索"
-            )
+            raise SearchHumanVerificationRequired("DuckDuckGo 要求人机验证")
         rows = []
         for result in document.xpath(
             "//*[contains(concat(' ', normalize-space(@class), ' '), ' result ')]"
@@ -151,7 +336,315 @@ class WebSearchClient:
             )
             snippet = " ".join(snippet_nodes[0].text_content().split()) if snippet_nodes else ""
             rows.append((" ".join(link.text_content().split()), href, snippet))
-        return _normalize_results(rows)
+        return _require_results_or_empty(
+            document,
+            _normalize_results(rows),
+            no_result_xpath=(
+                "//*[contains(concat(' ', normalize-space(@class), ' '), ' no-results ') "
+                "or contains(concat(' ', normalize-space(@class), ' '), ' results--no-results ')]"
+            ),
+            engine_name="DuckDuckGo",
+        )
+
+    @staticmethod
+    def _parse_bing(content: str) -> list[SearchResult]:
+        document = _parse_html(content, "Bing")
+        if document.xpath(
+            "//*[@id='b_captcha' or contains(concat(' ', normalize-space(@class), ' '), ' b_captcha ')]"
+        ):
+            raise SearchHumanVerificationRequired("Bing 要求人机验证")
+        rows = []
+        for result in document.xpath(
+            "//li[contains(concat(' ', normalize-space(@class), ' '), ' b_algo ')]"
+        ):
+            links = result.xpath(".//h2/a[@href]")
+            if not links:
+                continue
+            link = links[0]
+            snippets = result.xpath(
+                ".//*[contains(concat(' ', normalize-space(@class), ' '), ' b_caption ')]//p"
+            )
+            snippet = " ".join(snippets[0].text_content().split()) if snippets else ""
+            rows.append(
+                (
+                    " ".join(link.text_content().split()),
+                    _unwrap_bing_url(str(link.get("href") or "")),
+                    snippet,
+                )
+            )
+        return _require_results_or_empty(
+            document,
+            _normalize_results(rows),
+            no_result_xpath=(
+                "//*[contains(concat(' ', normalize-space(@class), ' '), ' b_no ') "
+                "or contains(concat(' ', normalize-space(@class), ' '), ' b_noResults ')]"
+            ),
+            engine_name="Bing",
+        )
+
+    @staticmethod
+    def _parse_baidu(content: str) -> list[SearchResult]:
+        document = _parse_html(content, "百度")
+        if document.xpath(
+            "//*[@id='verify-form' or @id='wappass_verify_form' "
+            "or contains(concat(' ', normalize-space(@class), ' '), ' verify ')]"
+        ):
+            raise SearchHumanVerificationRequired("百度要求人机验证")
+        rows = []
+        for result in document.xpath(
+            "//*[contains(concat(' ', normalize-space(@class), ' '), ' c-container ')]"
+        ):
+            links = result.xpath(".//h3//a[@href]")
+            if not links:
+                continue
+            link = links[0]
+            snippets = result.xpath(
+                ".//*[contains(concat(' ', normalize-space(@class), ' '), ' c-abstract ')]"
+            )
+            rows.append(
+                (
+                    link.text_content(),
+                    link.get("href"),
+                    snippets[0].text_content() if snippets else "",
+                )
+            )
+        return _require_results_or_empty(
+            document,
+            _normalize_results(rows),
+            no_result_xpath=(
+                "//*[contains(concat(' ', normalize-space(@class), ' '), "
+                "' op_sp_realtime_n_result ') or contains(text(), '没有找到相关结果')]"
+            ),
+            engine_name="百度",
+        )
+
+    @staticmethod
+    def _parse_so360(content: str) -> list[SearchResult]:
+        document = _parse_html(content, "360 搜索")
+        if document.xpath(
+            "//*[@id='verify' or @id='captcha' "
+            "or contains(concat(' ', normalize-space(@class), ' '), ' verify ') "
+            "or contains(concat(' ', normalize-space(@class), ' '), ' captcha ')]"
+        ):
+            raise SearchHumanVerificationRequired("360 搜索要求人机验证")
+        rows = []
+        for result in document.xpath(
+            "//*[contains(concat(' ', normalize-space(@class), ' '), ' res-list ')]"
+        ):
+            links = result.xpath(".//h3//a[@href]")
+            if not links:
+                continue
+            link = links[0]
+            href = str(link.get("href") or "")
+            target = str(link.get("data-mdurl") or "")
+            parsed_href = urlparse(href)
+            if not target and not (
+                _host_matches(parsed_href, "so.com")
+                and parsed_href.path.startswith("/link")
+            ):
+                target = href
+            snippets = result.xpath(
+                ".//*[contains(concat(' ', normalize-space(@class), ' '), ' res-desc ')]"
+            )
+            rows.append(
+                (
+                    link.text_content(),
+                    target,
+                    snippets[0].text_content() if snippets else "",
+                )
+            )
+        return _require_results_or_empty(
+            document,
+            _normalize_results(rows),
+            no_result_xpath=(
+                "//*[contains(concat(' ', normalize-space(@class), ' '), ' no-result ') "
+                "or contains(text(), '没有找到相关结果')]"
+            ),
+            engine_name="360 搜索",
+        )
+
+    @staticmethod
+    def _parse_sogou(content: str) -> list[SearchResult]:
+        document = _parse_html(content, "搜狗")
+        if document.xpath(
+            "//*[@id='verify' or @id='captcha' "
+            "or contains(concat(' ', normalize-space(@class), ' '), ' verify ') "
+            "or contains(concat(' ', normalize-space(@class), ' '), ' captcha ')]"
+        ):
+            raise SearchHumanVerificationRequired("搜狗要求人机验证")
+        rows = []
+        for result in document.xpath(
+            "//*[contains(concat(' ', normalize-space(@class), ' '), ' vrResult ')]"
+        ):
+            links = result.xpath(
+                ".//h3//a[contains(concat(' ', normalize-space(@class), ' '), ' resultLink ')][@href]"
+            )
+            if not links:
+                continue
+            link = links[0]
+            parsed = urlparse(urljoin(SOGOU_ENDPOINT, str(link.get("href") or "")))
+            target = parse_qs(parsed.query).get("url", [""])[0]
+            snippets = result.xpath(
+                ".//*[contains(concat(' ', normalize-space(@class), ' '), ' txt-summary ')]"
+            )
+            rows.append(
+                (
+                    link.text_content(),
+                    target,
+                    snippets[0].text_content() if snippets else "",
+                )
+            )
+        return _require_results_or_empty(
+            document,
+            _normalize_results(rows),
+            no_result_xpath=(
+                "//*[contains(concat(' ', normalize-space(@class), ' '), ' no-result ') "
+                "or contains(text(), '未找到相关结果')]"
+            ),
+            engine_name="搜狗",
+        )
+
+    @staticmethod
+    def _parse_shenma(content: str) -> list[SearchResult]:
+        lowered = content.lower()
+        compact = "".join(lowered.split())
+        if (
+            "_____tmd_____/punish" in lowered
+            or '"action":"captcha"' in compact
+            or "rgv587_flag" in lowered
+        ):
+            raise SearchHumanVerificationRequired("神马要求人机验证")
+        document = _parse_html(content, "神马")
+        if document.xpath(
+            "//*[@id='verify' or @id='captcha' "
+            "or contains(concat(' ', normalize-space(@class), ' '), ' verify ') "
+            "or contains(concat(' ', normalize-space(@class), ' '), ' captcha ')]"
+        ):
+            raise SearchHumanVerificationRequired("神马要求人机验证")
+        rows = []
+        title_links = document.xpath(
+            "//a[@href and contains(concat(' ', normalize-space(@class), ' '), "
+            "' qk-link-wrapper ')][.//*[contains(concat(' ', normalize-space(@class), "
+            "' '), ' qk-title-text ')]]"
+        )
+        for link in title_links:
+            containers = link.xpath(
+                "ancestor::*[contains(concat(' ', normalize-space(@class), ' '), ' sc ')][1]"
+            )
+            snippets = (
+                containers[0].xpath(
+                    ".//*[contains(concat(' ', normalize-space(@class), ' '), "
+                    "' qk-paragraph-text ')]"
+                )
+                if containers
+                else []
+            )
+            rows.append(
+                (
+                    link.text_content(),
+                    link.get("href"),
+                    snippets[0].text_content() if snippets else "",
+                )
+            )
+        for node in document.xpath(
+            "//script[@type='application/json' and @data-used-by='hydrate']/text()"
+        ):
+            try:
+                payload = json.loads(node)
+            except (TypeError, ValueError):
+                continue
+            for item in _walk_dicts(payload):
+                title = item.get("titleProps")
+                summary = item.get("summaryProps")
+                if not isinstance(title, dict):
+                    continue
+                rows.append(
+                    (
+                        _html_text(title.get("content")),
+                        title.get("dest_url"),
+                        _html_text(summary.get("content"))
+                        if isinstance(summary, dict)
+                        else "",
+                    )
+                )
+        return _require_results_or_empty(
+            document,
+            _normalize_results(rows),
+            no_result_xpath=(
+                "//*[contains(concat(' ', normalize-space(@class), ' '), ' no-result ') "
+                "or contains(text(), '没有找到相关结果')]"
+            ),
+            engine_name="神马",
+        )
+
+    @staticmethod
+    def _parse_google(content: str) -> list[SearchResult]:
+        document = _parse_html(content, "Google")
+        lowered = content.lower()
+        if (
+            document.xpath(
+                "//a[contains(@href, '/httpservice/retry/enablejs')] "
+                "| //form[contains(@action, '/sorry/')]"
+            )
+            or "unusual traffic" in lowered
+            or "我们的系统检测到" in content
+        ):
+            raise SearchHumanVerificationRequired(
+                "Google 要求人机验证；请检查桌面代理后重试"
+            )
+        rows = []
+        for heading in document.xpath("//*[@id='search']//a[@href]//h3"):
+            links = heading.xpath("ancestor::a[@href][1]")
+            if not links:
+                continue
+            link = links[0]
+            containers = heading.xpath(
+                "ancestor::div[.//*[@data-sncf or contains(concat(' ', "
+                "normalize-space(@class), ' '), ' VwiC3b ')]][1]"
+            )
+            snippets = (
+                containers[0].xpath(
+                    ".//*[@data-sncf or contains(concat(' ', normalize-space(@class), "
+                    "' '), ' VwiC3b ')]"
+                )
+                if containers
+                else []
+            )
+            rows.append(
+                (
+                    heading.text_content(),
+                    _unwrap_google_url(str(link.get("href") or "")),
+                    snippets[0].text_content() if snippets else "",
+                )
+            )
+        return _require_results_or_empty(
+            document,
+            _normalize_results(rows),
+            no_result_xpath=(
+                "//*[contains(text(), '找不到和您的查询相符的内容') "
+                "or contains(text(), 'did not match any documents')]"
+            ),
+            engine_name="Google",
+        )
+
+
+def _parse_html(content: str, engine_name: str):
+    try:
+        return html.fromstring(content)
+    except (TypeError, ValueError) as error:
+        raise RuntimeError(f"{engine_name} 返回了无法解析的页面") from error
+
+
+def _require_results_or_empty(
+    document,
+    results: list[SearchResult],
+    *,
+    no_result_xpath: str,
+    engine_name: str,
+) -> list[SearchResult]:
+    if results or document.xpath(no_result_xpath):
+        return results
+    raise RuntimeError(f"{engine_name} 页面结构无法解析")
 
 
 def _normalize_results(rows) -> list[SearchResult]:
@@ -176,6 +669,36 @@ def _normalize_results(rows) -> list[SearchResult]:
     return results
 
 
+def _unwrap_bing_url(value: str) -> str:
+    parsed = urlparse(value)
+    host = (parsed.hostname or "").lower()
+    if not (host == "bing.com" or host.endswith(".bing.com")) or not parsed.path.startswith("/ck/"):
+        return value
+    encoded = parse_qs(parsed.query).get("u", [""])[0]
+    if encoded.startswith("a1"):
+        encoded = encoded[2:]
+    if not encoded:
+        return ""
+    try:
+        padding = "=" * (-len(encoded) % 4)
+        target = urlsafe_b64decode(encoded + padding).decode("utf-8")
+    except (BinasciiError, UnicodeDecodeError, ValueError):
+        return ""
+    target_url = urlparse(target)
+    if target_url.scheme not in {"http", "https"} or not target_url.netloc:
+        return ""
+    return target
+
+
+def _unwrap_google_url(value: str) -> str:
+    parsed = urlparse(urljoin(GOOGLE_ENDPOINT, value))
+    if _host_matches(parsed, "google.com") or _host_matches(parsed, "google.com.hk"):
+        if parsed.path == "/url":
+            query = parse_qs(parsed.query)
+            return query.get("q", query.get("url", [""]))[0]
+    return parsed.geturl()
+
+
 def _origin(parsed) -> tuple[str, str, int | None]:
     try:
         port = parsed.port
@@ -184,6 +707,43 @@ def _origin(parsed) -> tuple[str, str, int | None]:
     if port is None:
         port = 443 if parsed.scheme == "https" else 80 if parsed.scheme == "http" else None
     return parsed.scheme.lower(), (parsed.hostname or "").lower(), port
+
+
+def _host_matches(parsed, domain: str) -> bool:
+    host = (parsed.hostname or "").lower()
+    domain = domain.lower()
+    return host == domain or host.endswith(f".{domain}")
+
+
+def _is_human_verification_redirect(endpoint: str, location: str) -> bool:
+    source = urlparse(endpoint)
+    target = urlparse(urljoin(endpoint, location))
+    if not (_host_matches(source, "baidu.com") and _host_matches(target, "baidu.com")):
+        return False
+    path = target.path.lower()
+    return _host_matches(target, "wappass.baidu.com") or any(
+        marker in path for marker in ("/captcha/", "/verify/", "tuxing")
+    )
+
+
+def _walk_dicts(value):
+    if isinstance(value, dict):
+        yield value
+        for child in value.values():
+            yield from _walk_dicts(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from _walk_dicts(child)
+
+
+def _html_text(value) -> str:
+    value = str(value or "")
+    if not value:
+        return ""
+    try:
+        return html.fromstring(f"<span>{value}</span>").text_content()
+    except (TypeError, ValueError):
+        return value
 
 
 def format_search_context(results: list[SearchResult]) -> str:

--- a/app/AIInterface.py
+++ b/app/AIInterface.py
@@ -60,6 +60,7 @@ from ai_assistant import (
     ModelCatalogClient,
     ModelOperationCancelled,
     SEARCH_ENGINES,
+    SearchAllSourcesVerificationRequired,
     SearchHumanVerificationRequired,
     WebSearchClient,
     collect_local_context,
@@ -140,11 +141,16 @@ class _AIRequestThread(QThread):
             if self.cancel_event.is_set():
                 self.cancelled.emit()
                 return
-        except SearchHumanVerificationRequired as error:
+        except SearchAllSourcesVerificationRequired as error:
             if self.cancel_event.is_set():
                 self.cancelled.emit()
             else:
                 self.webSearchDisabled.emit(_AIRequestFailure(str(error), self.session_id))
+        except SearchHumanVerificationRequired as error:
+            if self.cancel_event.is_set():
+                self.cancelled.emit()
+            else:
+                self.failed.emit(_AIRequestFailure(str(error), self.session_id))
         except Exception as error:
             if self.cancel_event.is_set():
                 self.cancelled.emit()
@@ -229,9 +235,6 @@ class AIInterface(QFrame):
         self.setObjectName("AIInterface")
         self.store = config_store or AIConfigStore()
         self.profile = self.store.load_profiles()[0]
-        self._lastSearxngEndpoint = (
-            self.profile.search_endpoint if self.profile.search_engine != "duckduckgo" else ""
-        )
         self.conversationStore = conversation_store or ConversationStore(
             self.store.path.with_name("ai_conversations.json")
         )
@@ -382,7 +385,7 @@ class AIInterface(QFrame):
         self.searchEngineCombo = ComboBox(widget)
         self.searchEngineCombo.addItems([name for _, name in SEARCH_ENGINES])
         self.searchEndpointEdit = LineEdit(widget)
-        self.searchEndpointEdit.setPlaceholderText("https://search.example/search")
+        self.searchEndpointEdit.setPlaceholderText(self.tr("内置直连搜索无需地址"))
         self.searchLimitCombo = ComboBox(widget)
         self.searchLimitCombo.addItems(["3", "5", "8", "10"])
         self.capabilityStatusLabel = CaptionLabel(
@@ -401,7 +404,6 @@ class AIInterface(QFrame):
         self.capabilityChecks["web_search"].toggled.connect(self._updateSearchControls)
         for checkbox in self.capabilityChecks.values():
             checkbox.toggled.connect(self._persistCapabilityPreferences)
-        self.searchEndpointEdit.editingFinished.connect(self._persistSearchPreferences)
         self.searchLimitCombo.currentTextChanged.connect(self._persistSearchPreferences)
 
     def _createSettingsTabs(self) -> None:
@@ -760,7 +762,7 @@ class AIInterface(QFrame):
             self.searchEngineCombo.setCurrentIndex(max(0, next(
                 (index for index, one in enumerate(SEARCH_ENGINES) if one[0] == self.profile.search_engine), 0
             )))
-            self.searchEndpointEdit.setText(self.profile.search_endpoint)
+            self.searchEndpointEdit.clear()
             self.searchLimitCombo.setCurrentText(str(self.profile.search_result_limit))
             self._updateSearchControls()
             self._onProtocolChanged(self.protocolCombo.currentIndex())
@@ -797,10 +799,6 @@ class AIInterface(QFrame):
 
     @pyqtSlot(int)
     def _onSearchEngineChanged(self, _index: int) -> None:
-        if self._currentSearchEngine() == "duckduckgo":
-            self.searchEndpointEdit.setText("https://html.duckduckgo.com/html/")
-        elif "duckduckgo.com" in self.searchEndpointEdit.text():
-            self.searchEndpointEdit.setText(self._lastSearxngEndpoint)
         self._updateSearchControls()
         if not self._loadingProfile:
             self._persistSearchPreferences()
@@ -808,13 +806,9 @@ class AIInterface(QFrame):
     @pyqtSlot()
     def _updateSearchControls(self) -> None:
         enabled = self.capabilityChecks["web_search"].isChecked()
-        needs_searxng = self._currentSearchEngine() != "duckduckgo"
         self.searchEngineCombo.setEnabled(enabled)
-        self.searchEndpointEdit.setEnabled(enabled and needs_searxng)
-        self.searchEndpointEdit.setPlaceholderText(
-            self.tr("填写 SearXNG 根地址，例如 https://search.example")
-            if needs_searxng else "https://html.duckduckgo.com/html/"
-        )
+        self.searchEndpointEdit.hide()
+        self.searchEndpointEdit.setEnabled(False)
         self.searchLimitCombo.setEnabled(enabled)
 
     def _persistCapabilityPreferences(self, *_args) -> None:
@@ -837,22 +831,15 @@ class AIInterface(QFrame):
         if self._loadingProfile:
             return
         engine = self._currentSearchEngine()
-        endpoint = self.searchEndpointEdit.text().strip()
-        if engine != "duckduckgo" and endpoint:
-            self._lastSearxngEndpoint = endpoint
         try:
             profile = replace(
                 self.profile,
                 search_engine=engine,
-                search_endpoint=endpoint,
+                search_endpoint="",
                 search_result_limit=int(self.searchLimitCombo.currentText() or 5),
             )
             self.store.save_profiles([profile])
         except Exception:
-            if engine != "duckduckgo":
-                self.capabilityStatusLabel.setText(
-                    self.tr("已选择主流引擎；填写有效的 SearXNG HTTPS 地址后会自动记住。")
-                )
             return
         self.profile = profile
 
@@ -868,7 +855,7 @@ class AIInterface(QFrame):
             model=self.modelCombo.currentText().strip(),
             capability_ids=self._selectedCapabilityIds(),
             search_engine=self._currentSearchEngine(),
-            search_endpoint=self.searchEndpointEdit.text().strip(),
+            search_endpoint="",
             search_result_limit=int(self.searchLimitCombo.currentText() or 5),
         )
 

--- a/test/ai_assistant/fixtures/baidu_organic_result.html
+++ b/test/ai_assistant/fixtures/baidu_organic_result.html
@@ -1,0 +1,12 @@
+<!--
+Source: /tmp/xjtu-probe-baidu-compressed-xjtu.body, captured 2026-08-17.
+Redacted: request ids, account state, scripts, styles, tracking fields, and unrelated results.
+-->
+<html><body>
+  <div class="result c-container xpath-log new-pmd" srcid="1599">
+    <h3 class="t">
+      <a href="https://www.baidu.com/link?url=fixture-token">西安交通大学</a>
+    </h3>
+    <div class="c-abstract">西安交通大学是教育部直属重点大学。</div>
+  </div>
+</body></html>

--- a/test/ai_assistant/fixtures/bing_organic_result.txt
+++ b/test/ai_assistant/fixtures/bing_organic_result.txt
@@ -1,0 +1,25 @@
+<!doctype html>
+<!--
+Sanitized from a no-cookie public Bing response captured on 2026-08-17.
+Scripts, styles, tracking identifiers, and unrelated results were removed.
+The selector-relevant b_algo, h2/a, and b_caption/p structure is retained.
+-->
+<html>
+  <body>
+    <ol id="b_results">
+      <li class="b_algo" data-id="" iid="SERP.fixture">
+        <div class="b_tpcn">
+          <a class="tilk" aria-label="en.xjtu.edu.cn" href="https://en.xjtu.edu.cn/">
+            <div class="tptxt"><div class="tptt">en.xjtu.edu.cn</div></div>
+          </a>
+        </div>
+        <h2 class="">
+          <a target="_blank" href="https://en.xjtu.edu.cn/">Xi'an Jiaotong University</a>
+        </h2>
+        <div class="b_caption">
+          <p class="b_lineclamp2">Teaching and learning news from XJTU.</p>
+        </div>
+      </li>
+    </ol>
+  </body>
+</html>

--- a/test/ai_assistant/fixtures/duckduckgo_challenge.txt
+++ b/test/ai_assistant/fixtures/duckduckgo_challenge.txt
@@ -1,0 +1,13 @@
+<!doctype html>
+<!--
+Sanitized from the DuckDuckGo HTTP 202 challenge structure independently
+recorded in cooperate.md on 2026-08-17. Challenge tokens and scripts were
+removed; the two parser-significant markers are retained.
+-->
+<html>
+  <body>
+    <div class="anomaly-modal">
+      <form id="challenge-form" action="/anomaly.js" method="post"></form>
+    </div>
+  </body>
+</html>

--- a/test/ai_assistant/fixtures/duckduckgo_organic_result.txt
+++ b/test/ai_assistant/fixtures/duckduckgo_organic_result.txt
@@ -1,0 +1,24 @@
+<!doctype html>
+<!--
+Sanitized from a no-cookie public DuckDuckGo HTML response captured on
+2026-08-17. Tracking tokens and unrelated results were removed while retaining
+the upstream result, result__a, and result__snippet structure.
+-->
+<html>
+  <body>
+    <div class="result results_links results_links_deep web-result">
+      <div class="links_main links_deep result__body">
+        <h2 class="result__title">
+          <a rel="nofollow" class="result__a"
+             href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fen.xjtu.edu.cn%2F">
+            Welcome to XJTU
+          </a>
+        </h2>
+        <a class="result__snippet"
+           href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fen.xjtu.edu.cn%2F">
+          Teaching and learning news from XJTU.
+        </a>
+      </div>
+    </div>
+  </body>
+</html>

--- a/test/ai_assistant/fixtures/google_enablejs.html
+++ b/test/ai_assistant/fixtures/google_enablejs.html
@@ -1,0 +1,8 @@
+<!--
+Source: /tmp/xjtu-probe-google-hk.body, captured 2026-08-17.
+Redacted: nonce, request id, scripts, styles, and unrelated page content.
+-->
+<html><body><noscript>
+  <meta content="0;url=/httpservice/retry/enablejs" http-equiv="refresh">
+  <a href="/httpservice/retry/enablejs">此处</a>
+</noscript></body></html>

--- a/test/ai_assistant/fixtures/shenma_challenge.html
+++ b/test/ai_assistant/fixtures/shenma_challenge.html
@@ -1,0 +1,9 @@
+<!--
+Source: /tmp/xjtu-shenma-current.body, captured 2026-08-17.
+Redacted: x5secdata, cookies, trace ids, query text, and the full punishment URL.
+-->
+<html><body><script>
+sessionStorage.x5referer = window.location.href;
+window.location.replace("/s/_____tmd_____/punish?redacted=1");
+window._config_ = {"action":"captcha","url":"/s/_____tmd_____/punish?redacted=1"};
+</script><!--rgv587_flag:sm--></body></html>

--- a/test/ai_assistant/fixtures/shenma_organic_result.html
+++ b/test/ai_assistant/fixtures/shenma_organic_result.html
@@ -1,0 +1,15 @@
+<!--
+Source: /tmp/xjtu-probe-shenma.body, captured 2026-08-17.
+Redacted: request ids, ad nodes, scripts, styles, images, tracking fields, and unrelated results.
+-->
+<html><body>
+  <section class="sc">
+    <a href="https://news.xjtu.edu.cn/" class="qk-link-wrapper">
+      <div class="qk-title-text-wrapper">
+        <div class="qk-title-text qk-font-bold">西安交通大学新闻网</div>
+      </div>
+    </a>
+    <div class="qk-paragraph-text">西安交通大学新闻门户。</div>
+  </section>
+  <script type="application/json" data-used-by="hydrate">{"data":{"initialData":{"titleProps":{"content":"西安交通大学","dest_url":"http://www.xjtu.edu.cn"},"summaryProps":{"content":"教育部直属重点大学。","dest_url":"http://www.xjtu.edu.cn"}}}}</script>
+</body></html>

--- a/test/ai_assistant/fixtures/so360_organic_result.html
+++ b/test/ai_assistant/fixtures/so360_organic_result.html
@@ -1,0 +1,12 @@
+<!--
+Source: /tmp/xjtu-probe-so360.body, captured 2026-08-17.
+Redacted: request ids, tracking payloads, scripts, styles, and unrelated results.
+-->
+<html><body><ul class="result">
+  <li class="res-list">
+    <h3 class="res-title">
+      <a href="https://www.so.com/link?m=redacted" data-mdurl="http://news.xjtu.edu.cn/">西安交通大学新闻网</a>
+    </h3>
+    <div class="res-rich"><p class="res-desc">西安交通大学新闻门户。</p></div>
+  </li>
+</ul></body></html>

--- a/test/ai_assistant/fixtures/sogou_organic_result.html
+++ b/test/ai_assistant/fixtures/sogou_organic_result.html
@@ -1,0 +1,12 @@
+<!--
+Source: /tmp/xjtu-probe-sogou-mobile.body, captured 2026-08-17.
+Redacted: request ids, session fields, tracking fields, scripts, styles, and unrelated results.
+-->
+<html><body>
+  <div class="vrResult" id="sogou_vr_fixture" type="1">
+    <h3 class="vr-tit">
+      <a class="resultLink" href="./redacted/tc?url=http%3A%2F%2Fmen.xjtu.edu.cn%2F&amp;linkid=title">Welcome to Xi'an Jiaotong University!</a>
+    </h3>
+    <a class="txt-summary"><div class="clamp2">XJTU teaching and research news.</div></a>
+  </div>
+</body></html>

--- a/test/ai_assistant/test_ai_features.py
+++ b/test/ai_assistant/test_ai_features.py
@@ -1,4 +1,5 @@
 import json
+import requests
 import sqlite3
 import tempfile
 import threading
@@ -13,16 +14,39 @@ from ai_assistant.markdown_render import render_markdown_fragment
 from ai_assistant.model_catalog import ModelCatalogClient, ModelOperationCancelled
 from ai_assistant.providers import PRESETS, ProviderConfig, validate_config
 from ai_assistant.web_search import (
+    BAIDU_ENDPOINT,
+    BING_ENDPOINT,
+    BUILTIN_ENGINES,
+    DUCKDUCKGO_ENDPOINT,
+    GOOGLE_ENDPOINT,
+    SEARCH_ENGINES,
+    SHENMA_ENDPOINT,
+    SO360_ENDPOINT,
+    SOGOU_ENDPOINT,
+    SearchAllSourcesVerificationRequired,
     SearchHumanVerificationRequired,
+    SearchResult,
     WebSearchClient,
+    _normalize_results,
     validate_search_settings,
 )
 from ai_assistant import ChatMessage
 from score_statistics import calculate_score_statistics
 
 
+FIXTURE_DIR = Path(__file__).with_name("fixtures")
+
+
 class FakeResponse:
-    def __init__(self, payload=None, *, status=200, text="", url="https://example.test/"):
+    def __init__(
+        self,
+        payload=None,
+        *,
+        status=200,
+        text="",
+        url="https://example.test/",
+        headers=None,
+    ):
         self.payload = payload
         self.status_code = status
         self.text = text
@@ -30,6 +54,7 @@ class FakeResponse:
         self.url = url
         self.closed = False
         self.encoding = "utf-8"
+        self.headers = dict(headers or {})
 
     def json(self):
         if isinstance(self.payload, Exception):
@@ -48,16 +73,27 @@ class FakeResponse:
 
 
 class FakeSession:
-    def __init__(self, get_response=None, post_response=None):
+    def __init__(self, get_response=None, post_response=None, head_response=None):
         self.get_response = get_response
         self.post_response = post_response
+        self.head_response = head_response
         self.calls = []
+
+    @staticmethod
+    def _next(response):
+        if isinstance(response, list):
+            response = response.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
 
     def get(self, url, **kwargs):
         self.calls.append(("GET", url, kwargs))
-        if isinstance(self.get_response, Exception):
-            raise self.get_response
-        return self.get_response
+        return self._next(self.get_response)
+
+    def head(self, url, **kwargs):
+        self.calls.append(("HEAD", url, kwargs))
+        return self._next(self.head_response)
 
     def post(self, url, **kwargs):
         self.calls.append(("POST", url, kwargs))
@@ -76,7 +112,7 @@ class IndependentProtocolConfigTest(unittest.TestCase):
         self.assertEqual(checked.preset_id, "deepseek")
         self.assertEqual(checked.protocol, "anthropic")
 
-    def test_v1_profile_migrates_to_default_off_capabilities_and_v2(self):
+    def test_v1_profile_migrates_to_default_off_capabilities_and_current_schema(self):
         with tempfile.TemporaryDirectory() as directory:
             path = Path(directory) / "profiles.json"
             profile = AIProfile.default()
@@ -89,6 +125,91 @@ class IndependentProtocolConfigTest(unittest.TestCase):
             self.assertEqual(loaded.capability_ids, ())
             store.save_profiles([loaded])
             self.assertEqual(json.loads(path.read_text(encoding="utf-8"))["version"], SCHEMA_VERSION)
+
+    def test_legacy_search_engines_migrate_to_available_sources(self):
+        with tempfile.TemporaryDirectory() as directory:
+            for version in (2, 3):
+                for legacy_engine in (
+                    "baidu",
+                    "google",
+                    "shenma",
+                    "duckduckgo",
+                    "searxng",
+                ):
+                    with self.subTest(version=version, engine=legacy_engine):
+                        path = Path(directory) / f"v{version}-{legacy_engine}.json"
+                        legacy = replace(
+                            AIProfile.default(),
+                            id=f"v{version}-{legacy_engine}",
+                            name="保留的用户配置",
+                            search_engine=legacy_engine,
+                            search_endpoint="https://search.example/",
+                            search_result_limit=8,
+                        )
+                        path.write_text(
+                            json.dumps({"version": version, "profiles": [legacy.__dict__]}),
+                            encoding="utf-8",
+                        )
+
+                        store = AIConfigStore(path, keyring_backend=object())
+                        loaded = store.load_profiles()[0]
+
+                        self.assertEqual(loaded.id, legacy.id)
+                        self.assertEqual(loaded.name, "保留的用户配置")
+                        self.assertEqual(loaded.search_engine, "auto")
+                        self.assertEqual(loaded.search_endpoint, "")
+                        self.assertEqual(loaded.search_result_limit, 8)
+                        self.assertEqual(store.last_error, "")
+
+    def test_v3_available_search_engines_keep_user_preferences(self):
+        with tempfile.TemporaryDirectory() as directory:
+            for engine in ("auto", "bing", "sogou", "so360"):
+                with self.subTest(engine=engine):
+                    path = Path(directory) / f"v3-{engine}.json"
+                    legacy = replace(
+                        AIProfile.default(),
+                        id=f"v3-{engine}",
+                        name="保留的用户配置",
+                        search_engine=engine,
+                        search_endpoint="https://ignored.example/",
+                        search_result_limit=8,
+                    )
+                    path.write_text(
+                        json.dumps({"version": 3, "profiles": [legacy.__dict__]}),
+                        encoding="utf-8",
+                    )
+
+                    store = AIConfigStore(path, keyring_backend=object())
+                    loaded = store.load_profiles()[0]
+
+                    self.assertEqual(loaded.id, legacy.id)
+                    self.assertEqual(loaded.name, "保留的用户配置")
+                    self.assertEqual(loaded.search_engine, engine)
+                    self.assertEqual(loaded.search_endpoint, "")
+                    self.assertEqual(loaded.search_result_limit, 8)
+                    self.assertEqual(store.last_error, "")
+
+    def test_current_search_profiles_round_trip_available_modes(self):
+        self.assertEqual(SCHEMA_VERSION, 4)
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "profiles.json"
+            profiles = [
+                replace(
+                    AIProfile.default(),
+                    id=engine,
+                    search_engine=engine,
+                    search_endpoint="https://ignored.example",
+                )
+                for engine, _label in SEARCH_ENGINES
+            ]
+            store = AIConfigStore(path, keyring_backend=object())
+            store.save_profiles(profiles)
+
+            loaded = {one.id: one for one in store.load_profiles()}
+
+        for engine, _label in SEARCH_ENGINES:
+            self.assertEqual(loaded[engine].search_engine, engine)
+            self.assertEqual(loaded[engine].search_endpoint, "")
 
     def test_retired_deepseek_models_are_migrated_and_blocked(self):
         with tempfile.TemporaryDirectory() as directory:
@@ -157,6 +278,50 @@ class ModelCatalogTest(unittest.TestCase):
 
 
 class WebSearchTest(unittest.TestCase):
+    @staticmethod
+    def retained_adapter_search(
+        session,
+        query="x",
+        *,
+        engine,
+        endpoint="",
+        limit=5,
+    ):
+        """Exercise retained adapters without reopening their public entry points."""
+
+        return WebSearchClient(session)._search_one(query, engine, endpoint, limit)
+
+    def test_search_catalog_has_approved_ids_labels_and_builtin_boundary(self):
+        self.assertEqual(
+            SEARCH_ENGINES,
+            (
+                ("auto", "自动（直连推荐）"),
+                ("bing", "Bing（直连）"),
+                ("sogou", "搜狗（直连）"),
+                ("so360", "360 搜索（直连）"),
+            ),
+        )
+        self.assertEqual(BUILTIN_ENGINES, {"auto", "bing", "sogou", "so360"})
+        for engine, _label in SEARCH_ENGINES:
+            self.assertEqual(
+                validate_search_settings(engine, "https://ignored.example"),
+                (engine, ""),
+            )
+
+    def test_disabled_search_sources_are_rejected_before_network_access(self):
+        disabled = ("baidu", "google", "shenma", "duckduckgo", "searxng")
+        for engine in disabled:
+            session = FakeSession()
+            with self.subTest(engine=engine), self.assertRaisesRegex(
+                ValueError, "暂不可用"
+            ):
+                WebSearchClient(session).search(
+                    "x",
+                    engine=engine,
+                    endpoint="https://search.example",
+                )
+            self.assertEqual(session.calls, [])
+
     def test_custom_searxng_is_bounded_and_parsed(self):
         response = FakeResponse(
             {"results": [
@@ -166,14 +331,58 @@ class WebSearchTest(unittest.TestCase):
             url="https://search.example/search?q=x&format=json",
         )
         session = FakeSession(get_response=response)
-        results = WebSearchClient(session).search(
-            "x", engine="searxng", endpoint="https://search.example", limit=5
+        results = self.retained_adapter_search(
+            session,
+            engine="searxng",
+            endpoint="https://search.example",
         )
         self.assertEqual([(one.title, one.url) for one in results], [("Result", "https://source.test/a")])
         self.assertEqual(session.calls[0][1], "https://search.example/search")
         self.assertFalse(session.calls[0][2]["allow_redirects"])
         self.assertTrue(session.calls[0][2]["stream"])
         self.assertTrue(response.closed)
+
+    def test_query_limit_and_searxng_payload_bounds_are_explicit(self):
+        client = WebSearchClient(FakeSession())
+        for query in ("", "   ", "x" * 501):
+            with self.subTest(query_length=len(query)), self.assertRaisesRegex(
+                ValueError, "1–500"
+            ):
+                client.search(query, engine="bing")
+        for limit in (0, 11):
+            with self.subTest(limit=limit), self.assertRaisesRegex(ValueError, "1–10"):
+                client.search("x", engine="bing", limit=limit)
+
+        explicit_empty = FakeResponse(
+            {"results": []},
+            url="https://search.example/search?q=x&format=json",
+        )
+        self.assertEqual(
+            self.retained_adapter_search(
+                FakeSession(get_response=explicit_empty),
+                engine="searxng",
+                endpoint="https://search.example",
+            ),
+            [],
+        )
+        invalid_responses = (
+            FakeResponse({}, url="https://search.example/search?q=x&format=json"),
+            FakeResponse(
+                {"results": {}},
+                url="https://search.example/search?q=x&format=json",
+            ),
+            FakeResponse(text="[]", url="https://search.example/search?q=x&format=json"),
+            FakeResponse(text="{", url="https://search.example/search?q=x&format=json"),
+        )
+        for response in invalid_responses:
+            with self.subTest(content=response.content), self.assertRaisesRegex(
+                RuntimeError, "无效 JSON"
+            ):
+                self.retained_adapter_search(
+                    FakeSession(get_response=response),
+                    engine="searxng",
+                    endpoint="https://search.example",
+                )
 
     def test_rejects_credentials_insecure_remote_and_cross_host_redirect(self):
         invalid = [
@@ -183,32 +392,515 @@ class WebSearchTest(unittest.TestCase):
         ]
         for endpoint in invalid:
             with self.subTest(endpoint=endpoint), self.assertRaises(ValueError):
-                validate_search_settings("searxng", endpoint)
+                self.retained_adapter_search(
+                    FakeSession(),
+                    engine="searxng",
+                    endpoint=endpoint,
+                )
         response = FakeResponse({"results": []}, url="https://evil.example/search")
         with self.assertRaisesRegex(RuntimeError, "未配置"):
-            WebSearchClient(FakeSession(get_response=response)).search(
-                "x", engine="searxng", endpoint="https://search.example"
+            self.retained_adapter_search(
+                FakeSession(get_response=response),
+                engine="searxng",
+                endpoint="https://search.example",
             )
+        self.assertTrue(response.closed)
 
     def test_timeout_redirect_and_oversized_stream_are_safe(self):
-        import requests
-
         with self.assertRaisesRegex(RuntimeError, "超时"):
-            WebSearchClient(FakeSession(get_response=requests.Timeout())).search(
-                "x", engine="searxng", endpoint="https://search.example"
+            self.retained_adapter_search(
+                FakeSession(get_response=requests.Timeout()),
+                engine="searxng",
+                endpoint="https://search.example",
             )
         redirect = FakeResponse({}, status=302, url="https://search.example/search")
         with self.assertRaisesRegex(RuntimeError, "重定向"):
-            WebSearchClient(FakeSession(get_response=redirect)).search(
-                "x", engine="searxng", endpoint="https://search.example"
+            self.retained_adapter_search(
+                FakeSession(get_response=redirect),
+                engine="searxng",
+                endpoint="https://search.example",
             )
+        self.assertTrue(redirect.closed)
+        failure = FakeResponse({}, status=503, url="https://search.example/search")
+        with self.assertRaisesRegex(RuntimeError, "HTTP 503"):
+            self.retained_adapter_search(
+                FakeSession(get_response=failure),
+                engine="searxng",
+                endpoint="https://search.example",
+            )
+        self.assertTrue(failure.closed)
         oversized = FakeResponse({}, url="https://search.example/search")
         oversized.content = b"x" * (2 * 1024 * 1024 + 1)
         with self.assertRaisesRegex(RuntimeError, "2 MiB"):
-            WebSearchClient(FakeSession(get_response=oversized)).search(
-                "x", engine="searxng", endpoint="https://search.example"
+            self.retained_adapter_search(
+                FakeSession(get_response=oversized),
+                engine="searxng",
+                endpoint="https://search.example",
             )
         self.assertTrue(oversized.closed)
+
+    def test_result_filter_rejects_unsafe_duplicates_and_empty_titles(self):
+        rows = [
+            ("ok", "https://source.test/a", "one"),
+            ("duplicate", "https://source.test/a", "two"),
+            ("", "https://source.test/b", "empty"),
+            ("bad", "https://user:secret@source.test/c", "credentials"),
+            ("bad", "http:///missing-host", "host"),
+            ("bad", "javascript:alert(1)", "scheme"),
+        ]
+        self.assertEqual(
+            _normalize_results(rows),
+            [SearchResult("ok", "https://source.test/a", "one")],
+        )
+
+    def test_bing_and_duckduckgo_distinguish_empty_from_unknown_structure(self):
+        explicit_empty = (
+            (
+                "bing",
+                BING_ENDPOINT,
+                '<html><ol id="b_results"><li class="b_no">没有与此相关的结果</li></ol></html>',
+            ),
+            (
+                "duckduckgo",
+                DUCKDUCKGO_ENDPOINT,
+                '<html><div class="no-results">No results.</div></html>',
+            ),
+        )
+        for engine, endpoint, content in explicit_empty:
+            with self.subTest(engine=engine):
+                response = FakeResponse(text=content, url=endpoint)
+                self.assertEqual(
+                    self.retained_adapter_search(
+                        FakeSession(get_response=response),
+                        engine=engine,
+                    ),
+                    [],
+                )
+                self.assertTrue(response.closed)
+
+        for engine, endpoint in (
+            ("bing", BING_ENDPOINT),
+            ("duckduckgo", DUCKDUCKGO_ENDPOINT),
+        ):
+            with self.subTest(engine=f"{engine}-unknown"):
+                response = FakeResponse(
+                    text="<html><body>changed layout</body></html>",
+                    url=endpoint,
+                )
+                with self.assertRaisesRegex(RuntimeError, "页面结构无法解析"):
+                    self.retained_adapter_search(
+                        FakeSession(get_response=response),
+                        engine=engine,
+                    )
+                self.assertTrue(response.closed)
+
+    def test_baidu_resolves_only_selected_results_with_safe_head_requests(self):
+        page = FakeResponse(
+            text=(FIXTURE_DIR / "baidu_organic_result.html").read_text(encoding="utf-8"),
+            url=f"{BAIDU_ENDPOINT}?wd=xjtu",
+        )
+        resolved = FakeResponse(
+            status=302,
+            url="https://www.baidu.com/link?url=fixture-token",
+            headers={"Location": "https://www.xjtu.edu.cn/"},
+        )
+        session = FakeSession(get_response=page, head_response=resolved)
+
+        results = self.retained_adapter_search(
+            session, "xjtu", engine="baidu", limit=1
+        )
+
+        self.assertEqual(
+            results,
+            [
+                SearchResult(
+                    "西安交通大学",
+                    "https://www.xjtu.edu.cn/",
+                    "西安交通大学是教育部直属重点大学。",
+                )
+            ],
+        )
+        self.assertEqual(session.calls[0][1], BAIDU_ENDPOINT)
+        self.assertEqual(session.calls[0][2]["params"], {"wd": "xjtu"})
+        method, url, kwargs = session.calls[1]
+        self.assertEqual((method, url), ("HEAD", "https://www.baidu.com/link?url=fixture-token"))
+        self.assertFalse(kwargs["allow_redirects"])
+        self.assertEqual(kwargs["timeout"], (10, 20))
+        self.assertTrue(page.closed)
+        self.assertTrue(resolved.closed)
+
+    def test_baidu_does_not_head_external_link_path(self):
+        page = FakeResponse(
+            text=(
+                '<div class="c-container"><h3><a '
+                'href="https://evil.example/link?url=opaque">外站结果</a></h3></div>'
+            ),
+            url=f"{BAIDU_ENDPOINT}?wd=x",
+        )
+        attacker_response = FakeResponse(
+            status=302,
+            headers={"Location": "https://attacker.example/payload"},
+        )
+        session = FakeSession(get_response=page, head_response=attacker_response)
+
+        results = self.retained_adapter_search(session, engine="baidu", limit=1)
+
+        self.assertEqual(
+            results,
+            [SearchResult("外站结果", "https://evil.example/link?url=opaque", "")],
+        )
+        self.assertEqual([call[0] for call in session.calls], ["GET"])
+        self.assertTrue(page.closed)
+        self.assertFalse(attacker_response.closed)
+
+    def test_baidu_drops_unsafe_and_failed_redirect_targets_with_limit_bound(self):
+        links = "".join(
+            '<div class="c-container"><h3><a href="https://www.baidu.com/link?url=%d">R%d</a></h3></div>'
+            % (index, index)
+            for index in range(6)
+        )
+        page = FakeResponse(
+            text=f"<html><body>{links}</body></html>",
+            url=f"{BAIDU_ENDPOINT}?wd=x",
+        )
+        javascript = FakeResponse(
+            status=302,
+            headers={"Location": "javascript:alert(1)"},
+        )
+        credentials = FakeResponse(
+            status=302,
+            headers={"Location": "https://user:secret@source.test/"},
+        )
+        missing = FakeResponse(status=302)
+        wrong_status = FakeResponse(
+            status=200,
+            headers={"Location": "https://source.test/ignored"},
+        )
+        session = FakeSession(
+            get_response=page,
+            head_response=[
+                javascript,
+                credentials,
+                missing,
+                wrong_status,
+                requests.Timeout(),
+            ],
+        )
+
+        self.assertEqual(
+            self.retained_adapter_search(session, engine="baidu", limit=5),
+            [],
+        )
+        self.assertEqual(
+            [call[0] for call in session.calls],
+            ["GET", "HEAD", "HEAD", "HEAD", "HEAD", "HEAD"],
+        )
+        self.assertTrue(
+            all(
+                response.closed
+                for response in (page, javascript, credentials, missing, wrong_status)
+            )
+        )
+
+    def test_baidu_distinguishes_challenge_empty_and_unknown_structure(self):
+        cases = (
+            (
+                '<html><div id="verify-form">安全验证</div></html>',
+                SearchHumanVerificationRequired,
+                "人机验证",
+            ),
+            (
+                '<html><div class="op_sp_realtime_n_result">没有找到相关结果</div></html>',
+                None,
+                "",
+            ),
+            ("<html><body>changed layout</body></html>", RuntimeError, "页面结构无法解析"),
+        )
+        for content, exception_type, message in cases:
+            with self.subTest(message=message or "empty"):
+                response = FakeResponse(text=content, url=BAIDU_ENDPOINT)
+                session = FakeSession(get_response=response)
+                if exception_type is None:
+                    self.assertEqual(
+                        self.retained_adapter_search(session, engine="baidu"),
+                        [],
+                    )
+                else:
+                    with self.assertRaisesRegex(exception_type, message):
+                        self.retained_adapter_search(session, engine="baidu")
+                self.assertTrue(response.closed)
+
+    def test_so360_uses_data_mdurl_without_requesting_tracking_link(self):
+        response = FakeResponse(
+            text=(FIXTURE_DIR / "so360_organic_result.html").read_text(encoding="utf-8"),
+            url=f"{SO360_ENDPOINT}?q=xjtu",
+        )
+        session = FakeSession(get_response=response)
+
+        results = WebSearchClient(session).search("xjtu", engine="so360", limit=3)
+
+        self.assertEqual(
+            results,
+            [
+                SearchResult(
+                    "西安交通大学新闻网",
+                    "http://news.xjtu.edu.cn/",
+                    "西安交通大学新闻门户。",
+                )
+            ],
+        )
+        self.assertEqual([call[1] for call in session.calls], [SO360_ENDPOINT])
+        self.assertEqual(session.calls[0][2]["params"], {"q": "xjtu"})
+
+    def test_sogou_decodes_url_parameter_without_requesting_tracking_link(self):
+        response = FakeResponse(
+            text=(FIXTURE_DIR / "sogou_organic_result.html").read_text(encoding="utf-8"),
+            url=f"{SOGOU_ENDPOINT}?keyword=xjtu",
+        )
+        session = FakeSession(get_response=response)
+
+        results = WebSearchClient(session).search("xjtu", engine="sogou", limit=3)
+
+        self.assertEqual(
+            results,
+            [
+                SearchResult(
+                    "Welcome to Xi'an Jiaotong University!",
+                    "http://men.xjtu.edu.cn/",
+                    "XJTU teaching and research news.",
+                )
+            ],
+        )
+        self.assertEqual([call[1] for call in session.calls], [SOGOU_ENDPOINT])
+        self.assertEqual(session.calls[0][2]["params"], {"keyword": "xjtu"})
+
+    def test_so360_and_sogou_drop_opaque_or_unsafe_tracking_targets(self):
+        cases = (
+            (
+                "so360",
+                SO360_ENDPOINT,
+                '<li class="res-list"><h3><a href="https://www.so.com/link?m=opaque">Opaque</a></h3></li>',
+            ),
+            (
+                "so360",
+                SO360_ENDPOINT,
+                '<li class="res-list"><h3><a href="https://www.so.com/link?m=x" data-mdurl="javascript:alert(1)">Unsafe</a></h3></li>',
+            ),
+            (
+                "sogou",
+                SOGOU_ENDPOINT,
+                '<div class="vrResult"><h3><a class="resultLink" href="./tc?url=https%3A%2F%2Fuser%3Asecret%40source.test%2F">Unsafe</a></h3></div>',
+            ),
+        )
+        for engine, endpoint, content in cases:
+            with self.subTest(engine=engine, content=content):
+                response = FakeResponse(text=content, url=endpoint)
+                with self.assertRaisesRegex(RuntimeError, "页面结构无法解析"):
+                    WebSearchClient(FakeSession(get_response=response)).search(
+                        "x", engine=engine
+                    )
+
+    def test_so360_and_sogou_distinguish_challenge_empty_and_unknown_structure(self):
+        cases = (
+            ("so360", SO360_ENDPOINT, '<div id="verify">captcha</div>', SearchHumanVerificationRequired),
+            ("so360", SO360_ENDPOINT, '<div class="no-result">没有找到相关结果</div>', None),
+            ("so360", SO360_ENDPOINT, '<div>changed layout</div>', RuntimeError),
+            ("sogou", SOGOU_ENDPOINT, '<div class="verify">captcha</div>', SearchHumanVerificationRequired),
+            ("sogou", SOGOU_ENDPOINT, '<div class="no-result">未找到相关结果</div>', None),
+            ("sogou", SOGOU_ENDPOINT, '<div>changed layout</div>', RuntimeError),
+        )
+        for engine, endpoint, content, exception_type in cases:
+            with self.subTest(engine=engine, exception=exception_type):
+                response = FakeResponse(text=content, url=endpoint)
+                client = WebSearchClient(FakeSession(get_response=response))
+                if exception_type is None:
+                    self.assertEqual(client.search("x", engine=engine), [])
+                else:
+                    with self.assertRaises(exception_type):
+                        client.search("x", engine=engine)
+
+    def test_shenma_parses_html_and_hydration_json_through_one_filter(self):
+        response = FakeResponse(
+            text=(FIXTURE_DIR / "shenma_organic_result.html").read_text(encoding="utf-8"),
+            url=f"{SHENMA_ENDPOINT}?q=xjtu",
+        )
+        session = FakeSession(get_response=response)
+
+        results = self.retained_adapter_search(
+            session, "xjtu", engine="shenma", limit=5
+        )
+
+        self.assertEqual(
+            results,
+            [
+                SearchResult(
+                    "西安交通大学新闻网",
+                    "https://news.xjtu.edu.cn/",
+                    "西安交通大学新闻门户。",
+                ),
+                SearchResult(
+                    "西安交通大学",
+                    "http://www.xjtu.edu.cn",
+                    "教育部直属重点大学。",
+                ),
+            ],
+        )
+        self.assertEqual([call[1] for call in session.calls], [SHENMA_ENDPOINT])
+        self.assertEqual(session.calls[0][2]["params"], {"q": "xjtu"})
+
+    def test_shenma_ignores_malformed_json_and_filters_unsafe_destinations(self):
+        malformed_with_html = """
+            <section class="sc">
+              <a href="https://safe.test/" class="qk-link-wrapper">
+                <div class="qk-title-text">Safe HTML</div>
+              </a>
+              <div class="qk-paragraph-text">Snippet</div>
+            </section>
+            <script type="application/json" data-used-by="hydrate">{broken</script>
+        """
+        response = FakeResponse(text=malformed_with_html, url=SHENMA_ENDPOINT)
+        self.assertEqual(
+            self.retained_adapter_search(
+                FakeSession(get_response=response),
+                engine="shenma",
+            ),
+            [SearchResult("Safe HTML", "https://safe.test/", "Snippet")],
+        )
+
+        unsafe = """
+            <section class="sc"><a href="javascript:alert(1)" class="qk-link-wrapper">
+              <div class="qk-title-text">Unsafe HTML</div></a></section>
+            <script type="application/json" data-used-by="hydrate">
+              {"data":{"titleProps":{"content":"Unsafe JSON","dest_url":"https://user:secret@source.test/"}}}
+            </script>
+        """
+        with self.assertRaisesRegex(RuntimeError, "页面结构无法解析"):
+            self.retained_adapter_search(
+                FakeSession(
+                    get_response=FakeResponse(text=unsafe, url=SHENMA_ENDPOINT)
+                ),
+                engine="shenma",
+            )
+
+    def test_shenma_distinguishes_challenge_empty_and_unknown_structure(self):
+        cases = (
+            ('<div class="captcha">captcha</div>', SearchHumanVerificationRequired),
+            (
+                (FIXTURE_DIR / "shenma_challenge.html").read_text(encoding="utf-8"),
+                SearchHumanVerificationRequired,
+            ),
+            ('<html><body><!--rgv587_flag:sm--></body></html>', SearchHumanVerificationRequired),
+            ('<div class="no-result">没有找到相关结果</div>', None),
+            ('<div>changed layout</div>', RuntimeError),
+        )
+        for content, exception_type in cases:
+            with self.subTest(exception=exception_type):
+                response = FakeResponse(text=content, url=SHENMA_ENDPOINT)
+                session = FakeSession(get_response=response)
+                if exception_type is None:
+                    self.assertEqual(
+                        self.retained_adapter_search(session, engine="shenma"),
+                        [],
+                    )
+                else:
+                    with self.assertRaises(exception_type):
+                        self.retained_adapter_search(session, engine="shenma")
+
+    def test_shenma_bxpunish_header_is_verification_before_body_parsing(self):
+        punished = FakeResponse(
+            text="<html><body>opaque punishment response</body></html>",
+            url=SHENMA_ENDPOINT,
+            headers={"bxpunish": "1"},
+        )
+
+        with self.assertRaisesRegex(
+            SearchHumanVerificationRequired,
+            "神马要求人机验证",
+        ):
+            WebSearchClient(FakeSession(get_response=punished))._fetch(
+                SHENMA_ENDPOINT,
+                params={"q": "x"},
+                accept="text/html",
+            )
+
+        self.assertTrue(punished.closed)
+
+    def test_google_enablejs_is_verification_not_empty_results(self):
+        response = FakeResponse(
+            text=(FIXTURE_DIR / "google_enablejs.html").read_text(encoding="utf-8"),
+            url=f"{GOOGLE_ENDPOINT}?q=xjtu",
+        )
+        with self.assertRaisesRegex(SearchHumanVerificationRequired, "Google 要求人机验证"):
+            self.retained_adapter_search(
+                FakeSession(get_response=response),
+                "xjtu",
+                engine="google",
+            )
+        self.assertTrue(response.closed)
+
+    def test_google_parser_accepts_standard_structure_without_live_fixture_claim(self):
+        content = """
+            <div id="search"><div class="result-contract">
+              <a href="https://www.xjtu.edu.cn/"><h3>西安交通大学</h3></a>
+              <div data-sncf="1">教育部直属重点大学。</div>
+            </div></div>
+        """
+        self.assertEqual(
+            WebSearchClient._parse_google(content),
+            [
+                SearchResult(
+                    "西安交通大学",
+                    "https://www.xjtu.edu.cn/",
+                    "教育部直属重点大学。",
+                )
+            ],
+        )
+
+    def test_google_fixed_endpoint_uses_system_network_without_proxy_parameters(self):
+        content = """
+            <div id="search"><div>
+              <a href="/url?q=https%3A%2F%2Fwww.xjtu.edu.cn%2F"><h3>西安交通大学</h3></a>
+              <div class="VwiC3b">XJTU</div>
+            </div></div>
+        """
+        response = FakeResponse(text=content, url=f"{GOOGLE_ENDPOINT}?q=xjtu")
+        session = FakeSession(get_response=response)
+
+        results = self.retained_adapter_search(
+            session, "xjtu", engine="google", limit=3
+        )
+
+        self.assertEqual(results[0].url, "https://www.xjtu.edu.cn/")
+        method, endpoint, kwargs = session.calls[0]
+        self.assertEqual((method, endpoint), ("GET", GOOGLE_ENDPOINT))
+        self.assertEqual(kwargs["params"], {"q": "xjtu"})
+        self.assertNotIn("proxies", kwargs)
+        self.assertFalse(kwargs["allow_redirects"])
+
+    def test_google_distinguishes_empty_unknown_and_unsafe_results(self):
+        empty = FakeResponse(
+            text="<div>找不到和您的查询相符的内容</div>",
+            url=GOOGLE_ENDPOINT,
+        )
+        self.assertEqual(
+            self.retained_adapter_search(
+                FakeSession(get_response=empty),
+                engine="google",
+            ),
+            [],
+        )
+
+        for content in (
+            "<div>changed layout</div>",
+            '<div id="search"><div><a href="javascript:alert(1)"><h3>Unsafe</h3></a></div></div>',
+        ):
+            with self.subTest(content=content):
+                response = FakeResponse(text=content, url=GOOGLE_ENDPOINT)
+                with self.assertRaisesRegex(RuntimeError, "页面结构无法解析"):
+                    self.retained_adapter_search(
+                        FakeSession(get_response=response),
+                        engine="google",
+                    )
 
     def test_duckduckgo_human_challenge_is_not_misreported_as_empty_results(self):
         challenged = FakeResponse(
@@ -216,26 +908,251 @@ class WebSearchTest(unittest.TestCase):
             url="https://html.duckduckgo.com/html/",
         )
         with self.assertRaisesRegex(SearchHumanVerificationRequired, "人机验证"):
-            WebSearchClient(FakeSession(get_response=challenged)).search(
-                "x", engine="duckduckgo", endpoint="https://ignored.example", limit=3
+            self.retained_adapter_search(
+                FakeSession(get_response=challenged),
+                engine="duckduckgo",
+                limit=3,
             )
         self.assertTrue(challenged.closed)
 
-    def test_mainstream_engines_use_configured_searxng_and_explicit_engine(self):
-        for engine in ("bing", "baidu", "google"):
-            response = FakeResponse(
-                {"results": [{"title": engine, "url": f"https://{engine}.example/result"}]},
-                url="https://search.example/search",
+    def test_bing_direct_search_parses_organic_results_and_filters_unsafe_urls(self):
+        real_fixture = (FIXTURE_DIR / "bing_organic_result.txt").read_text(
+            encoding="utf-8"
+        )
+        response = FakeResponse(
+            text=real_fixture.replace(
+                "</ol>",
+                '<li class="b_algo"><h2><a href="javascript:alert(1)">'
+                "Unsafe result</a></h2></li></ol>",
+            ),
+            url="https://www.bing.com/search?q=x",
+        )
+        session = FakeSession(get_response=response)
+
+        results = WebSearchClient(session).search(
+            "x", engine="bing", endpoint="https://ignored.example", limit=3
+        )
+
+        self.assertEqual(
+            [(one.title, one.url, one.snippet) for one in results],
+            [
+                (
+                    "Xi'an Jiaotong University",
+                    "https://en.xjtu.edu.cn/",
+                    "Teaching and learning news from XJTU.",
+                )
+            ],
+        )
+        self.assertEqual(session.calls[0][1], BING_ENDPOINT)
+        self.assertNotIn("engines", session.calls[0][2]["params"])
+
+    def test_bing_tracking_links_are_unwrapped_without_following_redirects(self):
+        response = FakeResponse(
+            text="""
+                <li class="b_algo"><h2><a href="https://www.bing.com/ck/a?u=a1aHR0cHM6Ly93d3cueGp0dS5lZHUuY24v">
+                  西安交通大学
+                </a></h2></li>
+            """,
+            url="https://www.bing.com/search?q=x",
+        )
+        session = FakeSession(get_response=response)
+
+        results = WebSearchClient(session).search("x", engine="bing", limit=3)
+
+        self.assertEqual(results[0].url, "https://www.xjtu.edu.cn/")
+        self.assertEqual(len(session.calls), 1)
+
+    def test_bing_and_duckduckgo_drop_opaque_tracking_urls(self):
+        cases = (
+            (
+                "bing",
+                BING_ENDPOINT,
+                '<li class="b_algo"><h2><a href="https://www.bing.com/ck/a?u=invalid">Opaque</a></h2></li>',
+            ),
+            (
+                "duckduckgo",
+                DUCKDUCKGO_ENDPOINT,
+                '<div class="result"><a class="result__a" href="/l/?kh=-1">Opaque</a></div>',
+            ),
+        )
+        for engine, endpoint, content in cases:
+            with self.subTest(engine=engine):
+                response = FakeResponse(text=content, url=endpoint)
+                with self.assertRaisesRegex(RuntimeError, "页面结构无法解析"):
+                    self.retained_adapter_search(
+                        FakeSession(get_response=response),
+                        engine=engine,
+                    )
+
+    def test_shenma_ignores_unscoped_application_json(self):
+        content = """
+            <script type="application/json">
+              {"titleProps":{"content":"Unrelated","dest_url":"https://source.test/"}}
+            </script>
+        """
+        with self.assertRaisesRegex(RuntimeError, "页面结构无法解析"):
+            self.retained_adapter_search(
+                FakeSession(
+                    get_response=FakeResponse(text=content, url=SHENMA_ENDPOINT)
+                ),
+                engine="shenma",
             )
-            session = FakeSession(get_response=response)
-            results = WebSearchClient(session).search(
-                "x", engine=engine, endpoint="https://search.example", limit=3
+
+    def test_auto_search_returns_bing_without_second_request(self):
+        bing = FakeResponse(
+            text=(FIXTURE_DIR / "bing_organic_result.txt").read_text(encoding="utf-8"),
+            url=BING_ENDPOINT,
+        )
+        session = FakeSession(get_response=[bing])
+
+        results = WebSearchClient(session).search("x", engine="auto", limit=3)
+
+        self.assertEqual([one.title for one in results], ["Xi'an Jiaotong University"])
+        self.assertEqual([call[1] for call in session.calls], [BING_ENDPOINT])
+
+    def test_auto_search_falls_back_bing_sogou_so360_in_fixed_order(self):
+        bing = FakeResponse(
+            text='<form id="b_captcha"></form>',
+            url=BING_ENDPOINT,
+        )
+        sogou = FakeResponse(
+            text='<div class="no-result">未找到相关结果</div>',
+            url=SOGOU_ENDPOINT,
+        )
+        so360 = FakeResponse(
+            text=(FIXTURE_DIR / "so360_organic_result.html").read_text(encoding="utf-8"),
+            url=SO360_ENDPOINT,
+        )
+        session = FakeSession(get_response=[bing, sogou, so360])
+
+        results = WebSearchClient(session).search("x", engine="auto", limit=3)
+
+        self.assertEqual([one.title for one in results], ["西安交通大学新闻网"])
+        self.assertEqual(
+            [call[1] for call in session.calls],
+            [BING_ENDPOINT, SOGOU_ENDPOINT, SO360_ENDPOINT],
+        )
+
+    def test_auto_search_stops_after_sogou_returns_results(self):
+        bing = FakeResponse(
+            text='<li class="b_no">没有与此相关的结果</li>',
+            url=BING_ENDPOINT,
+        )
+        sogou = FakeResponse(
+            text=(FIXTURE_DIR / "sogou_organic_result.html").read_text(encoding="utf-8"),
+            url=SOGOU_ENDPOINT,
+        )
+        session = FakeSession(get_response=[bing, sogou])
+
+        results = WebSearchClient(session).search("x", engine="auto", limit=3)
+
+        self.assertEqual([one.url for one in results], ["http://men.xjtu.edu.cn/"])
+        self.assertEqual(
+            [(call[0], call[1]) for call in session.calls],
+            [
+                ("GET", BING_ENDPOINT),
+                ("GET", SOGOU_ENDPOINT),
+            ],
+        )
+
+    def test_auto_search_reports_all_challenges_and_mixed_failures(self):
+        challenges = [
+            FakeResponse(text='<form id="b_captcha"></form>', url=BING_ENDPOINT),
+            FakeResponse(text='<div id="verify"></div>', url=SOGOU_ENDPOINT),
+            FakeResponse(text='<div id="verify"></div>', url=SO360_ENDPOINT),
+        ]
+        with self.assertRaisesRegex(
+            SearchAllSourcesVerificationRequired,
+            "均要求人机验证",
+        ):
+            WebSearchClient(FakeSession(get_response=challenges)).search(
+                "x", engine="auto", limit=3
             )
-            self.assertEqual(results[0].title, engine)
-            call = session.calls[0]
-            self.assertEqual(call[1], "https://search.example/search")
-            self.assertEqual(call[2]["params"]["engines"], engine)
-            self.assertEqual(call[2]["params"]["format"], "json")
+
+        with self.assertRaisesRegex(RuntimeError, "内置联网搜索暂时不可用"):
+            WebSearchClient(FakeSession(get_response=[
+                requests.Timeout(),
+                FakeResponse(
+                    text='<div class="no-result">未找到相关结果</div>',
+                    url=SOGOU_ENDPOINT,
+                ),
+                FakeResponse(text="<html>changed layout</html>", url=SO360_ENDPOINT),
+            ])).search("x", engine="auto", limit=3)
+
+    def test_baidu_captcha_redirect_and_ordinary_redirect_are_classified(self):
+        captcha_redirect = FakeResponse(
+            status=302,
+            url=BAIDU_ENDPOINT,
+            headers={
+                "Location": "https://wappass.baidu.com/static/captcha/tuxing_v2.html"
+            },
+        )
+        with self.assertRaisesRegex(SearchHumanVerificationRequired, "百度要求人机验证"):
+            WebSearchClient(FakeSession(get_response=captcha_redirect))._fetch(
+                BAIDU_ENDPOINT,
+                params={"wd": "x"},
+                accept="text/html",
+            )
+        ordinary_redirect = FakeResponse(
+            status=302,
+            url=BAIDU_ENDPOINT,
+            headers={"Location": "https://www.baidu.com/s?wd=redirected"},
+        )
+        with self.assertRaisesRegex(RuntimeError, "重定向"):
+            WebSearchClient(FakeSession(get_response=ordinary_redirect))._fetch(
+                BAIDU_ENDPOINT,
+                params={"wd": "x"},
+                accept="text/html",
+            )
+
+    def test_one_challenge_and_two_empty_sources_do_not_raise_aggregate_verification(self):
+        bing_challenge = FakeResponse(
+            text='<form id="b_captcha"></form>',
+            url=BING_ENDPOINT,
+        )
+        sogou_empty = FakeResponse(
+            text='<div class="no-result">未找到相关结果</div>',
+            url=SOGOU_ENDPOINT,
+        )
+        so360_empty = FakeResponse(
+            text='<div class="no-result">没有找到相关结果</div>',
+            url=SO360_ENDPOINT,
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "内置联网搜索暂时不可用"):
+            WebSearchClient(FakeSession(get_response=[
+                bing_challenge,
+                sogou_empty,
+                so360_empty,
+            ])).search("x", engine="auto", limit=3)
+
+    def test_auto_request_bound_is_three_pages_without_redirect_followups(self):
+        bing_empty = FakeResponse(
+            text='<li class="b_no">没有与此相关的结果</li>',
+            url=BING_ENDPOINT,
+        )
+        sogou_empty = FakeResponse(
+            text='<div class="no-result">未找到相关结果</div>',
+            url=SOGOU_ENDPOINT,
+        )
+        so360_empty = FakeResponse(
+            text='<div class="no-result">没有找到相关结果</div>',
+            url=SO360_ENDPOINT,
+        )
+        session = FakeSession(
+            get_response=[bing_empty, sogou_empty, so360_empty],
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "内置联网搜索暂时不可用"):
+            WebSearchClient(session).search("x", engine="auto", limit=10)
+
+        self.assertEqual(len(session.calls), 3)
+        self.assertEqual(sum(call[0] == "GET" for call in session.calls), 3)
+        self.assertEqual(sum(call[0] == "HEAD" for call in session.calls), 0)
+        self.assertNotIn(BAIDU_ENDPOINT, [call[1] for call in session.calls])
+        self.assertNotIn(SHENMA_ENDPOINT, [call[1] for call in session.calls])
+        self.assertNotIn(GOOGLE_ENDPOINT, [call[1] for call in session.calls])
+        self.assertNotIn(DUCKDUCKGO_ENDPOINT, [call[1] for call in session.calls])
 
 
 class CapabilityAndMarkdownTest(unittest.TestCase):

--- a/test/app/test_notice_search_ui.py
+++ b/test/app/test_notice_search_ui.py
@@ -30,8 +30,19 @@ from qfluentwidgets import (
     setTheme,
 )
 
-from ai_assistant import AIConfigStore, ChatMessage, PRESETS, ProviderConfig, collect_local_context
+from ai_assistant import (
+    AIConfigStore,
+    AIProfile,
+    ChatMessage,
+    PRESETS,
+    ProviderConfig,
+    collect_local_context,
+)
 from ai_assistant.markdown_render import render_markdown_fragment
+from ai_assistant.web_search import (
+    SearchAllSourcesVerificationRequired,
+    SearchHumanVerificationRequired,
+)
 from app.AIInterface import (
     AIInterface,
     _AIRequestFailure,
@@ -529,42 +540,187 @@ class AIInterfaceSmokeTest(unittest.TestCase):
         widget = self.create_interfaces()
         self.assertTrue(all(not checkbox.isChecked() for checkbox in widget.capabilityChecks.values()))
         self.assertFalse(widget.searchEngineCombo.isEnabled())
+        self.assertEqual(widget._currentSearchEngine(), "auto")
+        self.assertTrue(widget.searchEndpointEdit.isHidden())
         widget.capabilityChecks["schedule"].setChecked(True)
         self.assertTrue(widget.saveConfiguration())
         self.assertEqual(widget.profile.capability_ids, ("schedule",))
         widget.capabilityChecks["web_search"].setChecked(True)
-        searxng_index = widget.searchEngineCombo.findText("SearXNG（聚合）")
-        widget.searchEngineCombo.setCurrentIndex(searxng_index)
-        widget.searchEndpointEdit.setText("https://search.example")
-        self.assertTrue(widget.searchEndpointEdit.isEnabled())
+        bing_index = widget.searchEngineCombo.findText("Bing（直连）")
+        widget.searchEngineCombo.setCurrentIndex(bing_index)
+        self.assertTrue(widget.searchEndpointEdit.isHidden())
+        self.assertFalse(widget.searchEndpointEdit.isEnabled())
         self.assertTrue(widget.saveConfiguration())
-        self.assertEqual(widget.profile.search_engine, "searxng")
-        self.assertEqual(widget.profile.search_endpoint, "https://search.example")
+        self.assertEqual(widget.profile.search_engine, "bing")
+        self.assertEqual(widget.profile.search_endpoint, "")
 
-    def test_mainstream_search_choice_persists_and_captcha_turns_capability_off(self):
+    def test_search_catalog_labels_order_and_endpoint_visibility(self):
+        widget = self.create_interfaces()
+        labels = [
+            widget.searchEngineCombo.itemText(index)
+            for index in range(widget.searchEngineCombo.count())
+        ]
+        self.assertEqual(
+            labels,
+            [
+                "自动（直连推荐）",
+                "Bing（直连）",
+                "搜狗（直连）",
+                "360 搜索（直连）",
+            ],
+        )
+        widget.capabilityChecks["web_search"].setChecked(True)
+        for index in range(widget.searchEngineCombo.count()):
+            with self.subTest(label=labels[index]):
+                widget.searchEngineCombo.setCurrentIndex(index)
+                app.processEvents()
+                self.assertTrue(widget.searchEndpointEdit.isHidden())
+                self.assertFalse(widget.searchEndpointEdit.isEnabled())
+
+    def test_direct_search_choice_persists_and_aggregate_verification_turns_capability_off(self):
         with tempfile.TemporaryDirectory() as directory:
             path = Path(directory) / "profiles.json"
             first = AIInterface(config_store=AIConfigStore(path, keyring_backend=DummyKeyring()))
             self.addCleanup(first.close)
             first.capabilityChecks["web_search"].setChecked(True)
-            google = first.searchEngineCombo.findText("Google（通过 SearXNG）")
-            first.searchEngineCombo.setCurrentIndex(google)
-            first.searchEndpointEdit.setText("https://search.example")
-            first.searchEndpointEdit.editingFinished.emit()
+            bing = first.searchEngineCombo.findText("Bing（直连）")
+            first.searchEngineCombo.setCurrentIndex(bing)
             first.searchLimitCombo.setCurrentText("8")
             app.processEvents()
             second = AIInterface(config_store=AIConfigStore(path, keyring_backend=DummyKeyring()))
             self.addCleanup(second.close)
-            self.assertEqual(second._currentSearchEngine(), "google")
-            self.assertEqual(second.searchEndpointEdit.text(), "https://search.example/")
+            self.assertEqual(second._currentSearchEngine(), "bing")
+            self.assertEqual(second.searchEndpointEdit.text(), "")
+            self.assertTrue(second.searchEndpointEdit.isHidden())
             self.assertEqual(second.searchLimitCombo.currentText(), "8")
             self.assertTrue(second.capabilityChecks["web_search"].isChecked())
 
             with patch("app.AIInterface.InfoBar.warning"):
-                second._onWebSearchDisabled(_AIRequestFailure("DuckDuckGo 要求人机验证", "session"))
+                second._onWebSearchDisabled(
+                    _AIRequestFailure("自动模式的公开搜索服务均要求人机验证", "session")
+                )
             self.assertFalse(second.capabilityChecks["web_search"].isChecked())
             reloaded = AIConfigStore(path, keyring_backend=DummyKeyring()).load_profiles()[0]
             self.assertNotIn("web_search", reloaded.capability_ids)
+
+    def test_legacy_disabled_engine_loads_as_auto_without_endpoint(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "profiles.json"
+            legacy = {
+                **AIProfile.default().__dict__,
+                "search_engine": "google",
+                "search_endpoint": "https://search.example/",
+                "capability_ids": ("web_search",),
+            }
+            path.write_text(
+                json.dumps({"version": 2, "profiles": [legacy]}),
+                encoding="utf-8",
+            )
+
+            widget = AIInterface(
+                config_store=AIConfigStore(path, keyring_backend=DummyKeyring())
+            )
+            self.addCleanup(widget.close)
+            widget.show()
+            app.processEvents()
+
+            self.assertEqual(widget._currentSearchEngine(), "auto")
+            self.assertEqual(widget.searchEndpointEdit.text(), "")
+            self.assertTrue(widget.searchEndpointEdit.isHidden())
+            self.assertFalse(widget.searchEndpointEdit.isEnabled())
+            self.assertTrue(widget.capabilityChecks["web_search"].isChecked())
+
+    def test_request_thread_disables_search_only_after_aggregate_verification_failure(self):
+        class CapturingAIClient:
+            def __init__(self):
+                self.session = SimpleNamespace(close=lambda: None)
+
+            def complete(self, _messages, _config):
+                return SimpleNamespace(
+                    text="ok", model="fixture", input_tokens=1, output_tokens=1
+                )
+
+        class SuccessfulFallbackSearch:
+            def __init__(self):
+                self.session = SimpleNamespace(close=lambda: None)
+
+            def search(self, _query, **_settings):
+                return [SimpleNamespace(
+                    title="fallback result",
+                    url="https://source.test/result",
+                    snippet="available from the second built-in source",
+                )]
+
+        success_thread = _AIRequestThread(
+            [ChatMessage("user", "查询")],
+            ProviderConfig("openai", "https://api.example/v1", "fixture", "key"),
+            search_query="xjtu",
+            search_settings={"engine": "auto", "endpoint": "", "limit": 3},
+        )
+        success_thread.search_client = SuccessfulFallbackSearch()
+        success_thread.ai_client = CapturingAIClient()
+        outcomes = []
+        disabled = []
+        success_thread.succeeded.connect(outcomes.append)
+        success_thread.webSearchDisabled.connect(disabled.append)
+
+        success_thread.run()
+
+        self.assertEqual(outcomes[0].search_count, 1)
+        self.assertFalse(disabled)
+
+        class ExplicitSourceChallenged:
+            def __init__(self):
+                self.session = SimpleNamespace(close=lambda: None)
+
+            def search(self, _query, **_settings):
+                raise SearchHumanVerificationRequired("Google 要求人机验证")
+
+        explicit_thread = _AIRequestThread(
+            [ChatMessage("user", "查询")],
+            ProviderConfig("openai", "https://api.example/v1", "fixture", "key"),
+            search_query="xjtu",
+            search_settings={"engine": "google", "endpoint": "", "limit": 3},
+        )
+        explicit_thread.search_client = ExplicitSourceChallenged()
+        explicit_thread.ai_client = CapturingAIClient()
+        explicit_failures = []
+        explicit_disabled = []
+        explicit_thread.failed.connect(explicit_failures.append)
+        explicit_thread.webSearchDisabled.connect(explicit_disabled.append)
+
+        explicit_thread.run()
+
+        self.assertEqual(explicit_failures[0].message, "Google 要求人机验证")
+        self.assertFalse(explicit_disabled)
+
+        class AllSourcesChallenged:
+            def __init__(self):
+                self.session = SimpleNamespace(close=lambda: None)
+
+            def search(self, _query, **_settings):
+                raise SearchAllSourcesVerificationRequired(
+                    "自动模式的公开搜索服务均要求人机验证"
+                )
+
+        failure_thread = _AIRequestThread(
+            [ChatMessage("user", "查询")],
+            ProviderConfig("openai", "https://api.example/v1", "fixture", "key"),
+            search_query="xjtu",
+            search_settings={"engine": "auto", "endpoint": "", "limit": 3},
+        )
+        failure_thread.search_client = AllSourcesChallenged()
+        failure_thread.ai_client = CapturingAIClient()
+        aggregate_failures = []
+        provider_failures = []
+        failure_thread.webSearchDisabled.connect(aggregate_failures.append)
+        failure_thread.failed.connect(provider_failures.append)
+
+        failure_thread.run()
+
+        self.assertEqual(len(aggregate_failures), 1)
+        self.assertIn("均要求人机验证", aggregate_failures[0].message)
+        self.assertFalse(provider_failures)
 
     def test_model_dropdown_download_guard_markdown_status_and_placeholder(self):
         widget = self.create_interfaces()


### PR DESCRIPTION
## 背景

联网搜索当前同时暴露多个来源，但可稳定返回可解析结果的公开来源需要收紧为 Bing、搜狗和 360 搜索。本修复不尝试绕过 CAPTCHA、惩罚页或访问控制，而是准确分类验证响应并安全降级。

## 修改内容

- 公开目录和 UI 仅保留自动、Bing、搜狗、360 搜索。
- 自动模式固定按 `Bing → 搜狗 → 360` 回退，成功即停止。
- 百度指向 `wappass`/captcha/verify/tuxing 的验证重定向分类为人机验证；普通重定向仍按安全错误处理。
- 神马固定 endpoint 的非空 `bxpunish` 响应头，以及正文 punish/captcha/rgv587 标记分类为人机验证。
- 百度、神马、Google、DuckDuckGo、SearXNG 在公共入口联网前拒绝；保留适配器仅用于内部安全回归和后续复评。
- AI profile schema 升级到 v4；旧的已关闭来源安全迁移为 `auto` 并清空 endpoint，保留其它 profile 设置。
- 保留超时、2 MiB 响应上限、跨主机校验、危险 URL 过滤和重定向安全边界。

## 验证

- `test.ai_assistant.test_ai_features + test.app.test_notice_search_ui`
- 结果：Ran 97 tests，OK
- 五个变更模块通过 `py_compile`
- `git diff --check` 通过
- 候选分支基于当前上游 `main` `bc61b28`，压缩为单一提交 `6e6ff19`
- PR 仅包含 15 个代码、测试和离线 fixture 文件；不包含任何 Markdown、`docs/**`、`.mts` 或 `cooperate.md`

## 文件范围

- `ai_assistant/__init__.py`
- `ai_assistant/config.py`
- `ai_assistant/web_search.py`
- `app/AIInterface.py`
- `test/ai_assistant/test_ai_features.py`
- `test/app/test_notice_search_ui.py`
- `test/ai_assistant/fixtures/*.html`
- `test/ai_assistant/fixtures/*.txt`
