### PR TITLE
test(ci): 根据测试元数据生成分片清单

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -37,7 +37,9 @@ jobs:
       - name: Export validated test domains
         id: domains
         shell: bash
-        run: echo "domains=$(python -m test.ci.check_test_contract --format domain-json)" >> "$GITHUB_OUTPUT"
+        run: |
+          domains=$(python -m test.ci.check_test_contract --format domain-json)
+          echo "domains=$domains" >> "$GITHUB_OUTPUT"
 
   test-shards:
     name: ${{ matrix.domain.name }} (${{ matrix.platform.id }}, Python ${{ matrix.platform.python-version }})

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -18,6 +18,8 @@ jobs:
   test-contract:
     name: Test contract
     runs-on: ubuntu-22.04
+    outputs:
+      domains: ${{ steps.domains.outputs.domains }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -31,6 +33,11 @@ jobs:
 
       - name: Validate test inventory and workflow contract
         run: python -m unittest -v test.ci.test_pr_workflow
+
+      - name: Export validated test domains
+        id: domains
+        shell: bash
+        run: echo "domains=$(python -m test.ci.check_test_contract --format domain-json)" >> "$GITHUB_OUTPUT"
 
   test-shards:
     name: ${{ matrix.domain.name }} (${{ matrix.platform.id }}, Python ${{ matrix.platform.python-version }})
@@ -60,17 +67,7 @@ jobs:
             os: macos-15-intel
             python-version: "3.12"
             machine: x86_64
-        domain:
-          - id: ai
-            name: AI core and features
-          - id: qt-ui
-            name: Qt and desktop UI
-          - id: notification-crawler
-            name: Notifications and crawler
-          - id: auth-session
-            name: Authentication and sessions
-          - id: schedule
-            name: Schedule
+        domain: ${{ fromJSON(needs.test-contract.outputs.domains) }}
     env:
       PYTHONUTF8: "1"
       QT_QPA_PLATFORM: offscreen
@@ -116,17 +113,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        domain:
-          - id: ai
-            name: AI core and features
-          - id: qt-ui
-            name: Qt and desktop UI
-          - id: notification-crawler
-            name: Notifications and crawler
-          - id: auth-session
-            name: Authentication and sessions
-          - id: schedule
-            name: Schedule
+        domain: ${{ fromJSON(needs.test-contract.outputs.domains) }}
     env:
       PYTHONUTF8: "1"
       QT_QPA_PLATFORM: offscreen
@@ -226,7 +213,7 @@ jobs:
           XDG_CONFIG_HOME: ${{ runner.temp }}/xjtu-test-config
           XDG_DATA_HOME: ${{ runner.temp }}/xjtu-test-data
           XDG_CACHE_HOME: ${{ runner.temp }}/xjtu-test-cache
-        run: uv run --frozen python -m unittest -v test.ai_assistant.test_ai_features test.app.test_notice_search_ui test.notification.test_notification_sources test.app.test_notice_thread test.schedule.test_lesson test.test_crawler_challenge
+        run: uv run --frozen python -m test.ci.run_test_regressions
 
   ci-gate:
     name: CI Gate

--- a/docs/development/notification.md
+++ b/docs/development/notification.md
@@ -312,10 +312,10 @@ python -m scripts.smoke_notification_sources --workers 8
 ```
 
 回归模块由各测试文件中的 `TEST_REGRESSION = True` 标记自动发现；新增或调整回归测试时只需修改
-对应测试文件，不要在本文档维护模块列表。本命令现在统一运行 CI 标记的 6 个历史回归模块；此前
-文档命令额外包含的 `test_ai_core`、`test_ctrl_c`、`test_qrcode_login` 不再由此命令单独运行，
-而 `test_notice_thread`、`test_schedule_lesson` 已纳入统一入口。若需核对当前集合，请运行
-`python -m test.ci.check_test_contract --format markdown`。
+对应测试文件，不要在本文档维护模块列表。本命令现在统一运行 CI 标记的历史回归模块；此前文档命令
+额外包含的 `test_ai_core`、`test_ctrl_c`、`test_qrcode_login` 不再由此命令单独运行，而
+`test_notice_thread`、`test_schedule_lesson` 已纳入统一入口。当前数量和完整列表请运行
+`python -m test.ci.check_test_contract --format markdown` 查看。
 
 全仓发现应显式指定顶层目录：`python -m unittest discover -s test -t .`。只写
 `python -m unittest discover -s test` 可能让测试子包遮蔽产品同名包。

--- a/docs/development/notification.md
+++ b/docs/development/notification.md
@@ -312,7 +312,10 @@ python -m scripts.smoke_notification_sources --workers 8
 ```
 
 回归模块由各测试文件中的 `TEST_REGRESSION = True` 标记自动发现；新增或调整回归测试时只需修改
-对应测试文件，不要在本文档维护模块列表。
+对应测试文件，不要在本文档维护模块列表。本命令现在统一运行 CI 标记的 6 个历史回归模块；此前
+文档命令额外包含的 `test_ai_core`、`test_ctrl_c`、`test_qrcode_login` 不再由此命令单独运行，
+而 `test_notice_thread`、`test_schedule_lesson` 已纳入统一入口。若需核对当前集合，请运行
+`python -m test.ci.check_test_contract --format markdown`。
 
 全仓发现应显式指定顶层目录：`python -m unittest discover -s test -t .`。只写
 `python -m unittest discover -s test` 可能让测试子包遮蔽产品同名包。

--- a/docs/development/notification.md
+++ b/docs/development/notification.md
@@ -306,17 +306,13 @@ XDG_STATE_HOME=/tmp/xjtu-test-state \
 XDG_CONFIG_HOME=/tmp/xjtu-test-config \
 XDG_DATA_HOME=/tmp/xjtu-test-data \
 QT_QPA_PLATFORM=offscreen \
-python -m unittest \
-  test.ai_assistant.test_ai_core \
-  test.ai_assistant.test_ai_features \
-  test.app.test_notice_search_ui \
-  test.app.test_ctrl_c \
-  test.auth.test_qrcode_login \
-  test.notification.test_notification_sources \
-  test.test_crawler_challenge
+python -m test.ci.run_test_regressions
 
 python -m scripts.smoke_notification_sources --workers 8
 ```
+
+回归模块由各测试文件中的 `TEST_REGRESSION = True` 标记自动发现；新增或调整回归测试时只需修改
+对应测试文件，不要在本文档维护模块列表。
 
 全仓发现应显式指定顶层目录：`python -m unittest discover -s test -t .`。只写
 `python -m unittest discover -s test` 可能让测试子包遮蔽产品同名包。

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -1,6 +1,6 @@
 # 测试与 Pull Request 门禁
 
-每个 Pull Request 会先执行 `Test contract`，再把五个测试域分发到五个 hosted 平台和
+每个 Pull Request 会先执行 `Test contract`，再把当前定义的测试域分发到各 hosted 平台和
 Linux ARM64 QEMU，另外运行独立的 `Existing bug regressions`，最后汇总为
 `PR Tests / CI Gate`。合同、分片、回归或 Gate 处于等待、失败、取消或跳过状态时不得合并。
 
@@ -12,7 +12,7 @@ push，让 `synchronize` 触发新运行。GitHub 原生 rerun 权限由仓库�
 ## 本地测试
 
 先按[开发环境搭建](./setup.md)安装锁定依赖，然后用一行命令运行与 PR CI 相同的测试合同和
-五个测试域：
+当前定义的全部测试域：
 
 ```bash
 uv run --frozen local_test.py
@@ -27,30 +27,40 @@ uv run --frozen local_test.py
 uv run --frozen python -m test.ci.check_test_contract
 ```
 
-五个测试域使用同一份清单和入口：
+测试域使用同一份清单和入口；运行全部域时直接使用上面的 `local_test.py`，它会从唯一的稳定域定义
+读取当前域并逐个运行。需要单独运行某个域时，将该域 ID 传给 runner：
 
 ```bash
-uv run --frozen python -m test.ci.run_test_shard --domain ai
-uv run --frozen python -m test.ci.run_test_shard --domain qt-ui
-uv run --frozen python -m test.ci.run_test_shard --domain notification-crawler
-uv run --frozen python -m test.ci.run_test_shard --domain auth-session
-uv run --frozen python -m test.ci.run_test_shard --domain schedule
+uv run --frozen python -m test.ci.run_test_shard --domain <domain-id>
 ```
 
-域清单当前覆盖以下 25 个模块，每个产品测试模块恰好属于一个主测试域：
+`test/ci/shards.py` 只保存一份稳定的域 ID、Actions 显示名和矩阵顺序；合同通过后会把这份定义输出为
+JSON，hosted 与 ARM64 QEMU 矩阵都自动读取它。主域和历史回归目标则由产品测试文件自己的 marker 发现，
+不维护共享模块列表。每个产品测试文件在顶层声明自己的归属，例如：
 
-| 域 ID | Actions 显示名 | 模块 | 2026-08-24 本地完整环境用例数 |
-|---|---|---|---:|
-| `ai` | AI core and features | `test.ai_assistant.test_ai_core`、`test.ai_assistant.test_ai_features` | 71 |
-| `qt-ui` | Qt and desktop UI | `test.app.test_campus_job`、`test.app.test_campus_pages`、`test.app.test_campus_registration`、`test.app.test_ctrl_c`、`test.app.test_notice_search_ui`、`test.app.test_notice_thread`、`test.library.test_booking_parse` | 99 |
- (fix(ci): 登记图书馆测试到分片契约，新增模块纳入 CI 门禁)
-| `notification-crawler` | Notifications and crawler | `test.notification.test_notification_sources`、`test.test_crawler_challenge` | 28 |
-| `auth-session` | Authentication and sessions | `test.auth.login`、`test.auth.test_qrcode_login`、`test.auth.util`、`test.fitness.test_session`、`test.hello.test_session`、`test.sessions.session_manager` | 56（无凭据时 2 项跳过） |
-| `schedule` | Schedule | `test.fitness.test_score_zero`、`test.fitness.test_years`、`test.hello.test_profile`、`test.jwxt.test_calendar_api`、`test.jwxt.test_calendar_week`、`test.jwxt.test_school_course_headers`、`test.schedule.test_lesson`、`test.schedule.test_schedule` | 46 |
+```python
+TEST_DOMAIN = "qt-ui"
+```
 
-域按产品职责划分，不按本地用例数量凑齐。上述实测中 Qt/UI 比 AI 更慢，而 runner 启动、依赖安装
-和平台差异还会主导云端耗时；因此本地用例数和耗时不能代替 GitHub-hosted job 时长，也不能单独
-作为重分域或裁剪平台的依据。
+合同检查器通过 AST 扫描 `test/**/*.py` 读取这些 marker，不导入或执行测试模块。新增普通测试时只需在
+新增文件中添加一个合法的 `TEST_DOMAIN`；如需加入独立历史回归重跑，再在同一文件增加
+`TEST_REGRESSION = True`。加入现有域且新增独立测试文件时，不需要修改共享分片清单、workflow 命令、
+测试数量或本文档。因此多个 PR 各自新增测试时只修改自己的测试文件，先合入一个 PR 不会让其余 PR 因共享
+清单产生冲突。新增域只需修改唯一的稳定域定义，两个 workflow 矩阵会自动读取；两个 PR 修改同一测试文件时
+仍按普通 Git 规则处理。迁移前创建的
+在途分支 rebase 后，只需给自己新增的测试文件补 marker。每个产品测试模块必须恰好属于一个主测试域；主域
+marker 缺失、重复、非字符串、未知域，以及回归 marker 重复或非布尔值、意外声明、缺失文件或语法错误都会
+让合同失败。
+
+需要查看当前运行时清单时，直接执行：
+
+```bash
+uv run --frozen python -m test.ci.check_test_contract --format markdown
+```
+
+命令会根据 AST 发现结果计算总模块数，并按稳定域顺序输出各域模块数和模块列表；输出只用于检查或 CI 日志，
+不写回仓库。域按产品职责划分，不按本地用例数量凑齐；本地用例数和耗时不能代替 GitHub-hosted job 时长，
+也不能单独作为重分域或裁剪平台的依据。
 
 `product_test_modules()` 扫描 `test/**/*.py`，只排除任意目录中的 `__init__.py` 和精确的
 `test/ci/**` 子树。顶层 `test/ci.py` 和路径如 `test/feature/ci/test_case.py` 仍是产品测试；新增、删除、重复、意外
@@ -67,8 +77,11 @@ GUI 测试使用 Qt 离屏和软件渲染：
 
 ```bash
 QT_QPA_PLATFORM=offscreen QT_OPENGL=software \
-  uv run --frozen python -m unittest test.app.test_notice_search_ui -v
+  uv run --frozen python -m unittest <module> -v
 ```
+
+其中 `<module>` 是需要单独检查的测试模块导入名；若要运行完整的 Qt/UI 域，请使用上面的
+`test.ci.run_test_shard --domain <domain-id>` 并传入 `qt-ui`。
 
 认证/会话和 UI 测试会创建日志、临时配置以及应用数据/缓存。CI 将
 `XDG_STATE_HOME`、`XDG_CONFIG_HOME`、`XDG_DATA_HOME` 和 `XDG_CACHE_HOME` 指向 runner
@@ -84,22 +97,17 @@ cookie、代理或其它凭据。本地通过只证明实际主机和解释器�
 每个 bug 修复必须包含一个使用本地 fixture、mock 或临时目录的回归测试；不得依赖实时学校
 系统、搜索引擎或其它不稳定外部服务。
 
-`Existing bug regressions` 会明确重跑以下已登记模块：
-
-- `test.ai_assistant.test_ai_features`
-- `test.app.test_notice_search_ui`
-- `test.notification.test_notification_sources`
-- `test.app.test_notice_thread`
-- `test.schedule.test_lesson`
-- `test.test_crawler_challenge`
-
-这些是对主域的有意重跑，不替代主域分片，也不影响“每个产品测试模块恰好属于一个主测试域”
-的定义，更不允许隐藏额外模块。合同、30 个分片和回归检查都通过后，聚合 Gate 才会变绿。
+顶层声明 `TEST_REGRESSION = True` 的模块会由 AST 动态发现，`Existing bug regressions` 通过
+`python -m test.ci.run_test_regressions` 重跑当前发现结果。`False` 或未声明表示不加入这次额外重跑；
+marker 必须是单一、直接的布尔字面量赋值，不能使用变量、条件或链式赋值。这些是对主域的有意重跑，
+不替代主域分片，也不影响“每个产品测试模块恰好属于一个主测试域”的定义，更不允许隐藏额外模块。
+新增回归目标只修改拥有该测试的文件，不需同步编辑 `shards.py`、workflow 或文档。合同、各平台 × 当前域定义的分片和
+回归检查都通过后，聚合 Gate 才会变绿。
 
 ## 多平台矩阵
 
-主测试域为 6 个平台 × 5 个域 = 30 个分片；加上 `Test contract`、
-`Existing bug regressions` 和 `CI Gate`，预期共 33 个 checks：
+主测试域由各平台分别运行当前稳定域定义；加上 `Test contract`、
+`Existing bug regressions` 和 `CI Gate`。域定义变化时，矩阵与 check 数会自动随之变化：
 
 | 平台 ID | runner/执行方式 | Python | 架构与目的 |
 |---|---|---:|---|
@@ -110,7 +118,7 @@ cookie、代理或其它凭据。本地通过只证明实际主机和解释器�
 | `macos-intel-py312` | macOS 15 Intel hosted | 3.12 | x86_64，Intel Mac |
 | `linux-arm64-qemu-py310` | Ubuntu 22.04 hosted 上的 QEMU guest | 系统 Python 3.10 | aarch64，Linux ARM64 兼容验证 |
 
-30 个主分片统一显示为
+主分片统一显示为
 `<domain display name> (<platform id>, Python <version>)`。例如
 `Qt and desktop UI (linux-arm64-qemu-py310, Python 3.10)`；域、平台 ID 和 Python 版本可直接从
 check 名称定位。
@@ -124,7 +132,7 @@ ARM64 QEMU 安装系统 PyQt5、QtMultimedia、QtSvg、QtX11Extras，在带
 QEMU 下 QtMultimedia/GStreamer 可能在 `qt-ui` 域已经输出全部成功结果后的解释器 teardown
 阶段崩溃，因此只有该域使用 `--hard-exit-on-success`：runner 先确认 suite 成功并刷新
 stdout/stderr，再以 0 跳过 teardown。任何收集、导入或断言失败仍返回非零；hosted 平台和
-其它四个 QEMU 域都禁止该选项。这个兼容措施仍须由 exact-SHA 的自然 ARM job 验证。
+其它 QEMU 域都禁止该选项。这个兼容措施仍须由 exact-SHA 的自然 ARM job 验证。
 
 构建、发布和定时任务继续由独立的 `.github/workflows/build_linux.yml`、`build_macos.yml`、
 `build_windows.yml`、`deploy.yml`、`empty_room.yml`、`upload.yml` 和 `update_aur.yml` 负责；
@@ -137,7 +145,7 @@ PR 测试成功不能替代构建成功，也不能替代发布或定时任务�
 
 维护者合并前应确认：
 
-1. `Test contract`、30 个分片、`Existing bug regressions` 和 `CI Gate` 均成功；
+1. `Test contract`、各平台 × 当前域定义的分片、`Existing bug regressions` 和 `CI Gate` 均成功；
 2. 新 bug 有对应回归测试；
 3. PR 描述列出实际运行的命令和未覆盖环境；
 4. 平台特定改动已扩展矩阵或给出独立验证证据。

--- a/test/ai_assistant/test_ai_core.py
+++ b/test/ai_assistant/test_ai_core.py
@@ -3,6 +3,8 @@ import tempfile
 import unittest
 from pathlib import Path
 
+TEST_DOMAIN = "ai"
+
 import requests
 
 from ai_assistant import (

--- a/test/ai_assistant/test_ai_features.py
+++ b/test/ai_assistant/test_ai_features.py
@@ -7,6 +7,9 @@ import unittest
 from dataclasses import replace
 from pathlib import Path
 
+TEST_DOMAIN = "ai"
+TEST_REGRESSION = True
+
 from ai_assistant.capabilities import collect_local_context
 from ai_assistant.config import AIConfigStore, AIProfile, SCHEMA_VERSION, validate_profile
 from ai_assistant.conversations import ConversationStore, MAX_CONTENT_CHARACTERS

--- a/test/app/test_campus_job.py
+++ b/test/app/test_campus_job.py
@@ -2,6 +2,8 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
+TEST_DOMAIN = "qt-ui"
+
 import requests
 
 from auth import ServerError

--- a/test/app/test_campus_pages.py
+++ b/test/app/test_campus_pages.py
@@ -4,6 +4,8 @@ import base64
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
+TEST_DOMAIN = "qt-ui"
+
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
 from PyQt5.QtCore import Qt

--- a/test/app/test_campus_registration.py
+++ b/test/app/test_campus_registration.py
@@ -3,6 +3,8 @@ import unittest
 from pathlib import Path
 from unittest.mock import Mock, patch
 
+TEST_DOMAIN = "qt-ui"
+
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
 from PyQt5.QtCore import Qt

--- a/test/app/test_ctrl_c.py
+++ b/test/app/test_ctrl_c.py
@@ -2,6 +2,8 @@ import signal
 import unittest
 from unittest.mock import Mock, patch
 
+TEST_DOMAIN = "qt-ui"
+
 from app.ctrl_c import install_ctrl_c_handler
 
 

--- a/test/app/test_notice_search_ui.py
+++ b/test/app/test_notice_search_ui.py
@@ -12,6 +12,9 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
+TEST_DOMAIN = "qt-ui"
+TEST_REGRESSION = True
+
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 os.environ.setdefault("XDG_STATE_HOME", "/tmp/xjtu-test-state")
 os.environ.setdefault("XDG_CONFIG_HOME", "/tmp/xjtu-test-config")

--- a/test/app/test_notice_thread.py
+++ b/test/app/test_notice_thread.py
@@ -3,6 +3,9 @@ import unittest
 from app.threads.NoticeThread import NoticeThread
 from notification import NotificationManager
 
+TEST_DOMAIN = "qt-ui"
+TEST_REGRESSION = True
+
 
 class NoticeThreadStatusTest(unittest.TestCase):
     def test_skipped_source_does_not_emit_crawl_error(self):

--- a/test/auth/login.py
+++ b/test/auth/login.py
@@ -3,6 +3,8 @@ import unittest
 from auth import JWXT_LOGIN_URL, WEBVPN_LOGIN_URL
 from auth.new_login import NewLogin
 
+TEST_DOMAIN = "auth-session"
+
 # 为了进行此测试，您需要拥有西安交通大学统一身份认证登录的账号
 # 请将账号的用户名与密码填写在下方，然后执行测试
 # 用户名与密码仅会用于登录西安交通大学相关的系统，不会被记录或发送到其他任何服务器。

--- a/test/auth/test_qrcode_login.py
+++ b/test/auth/test_qrcode_login.py
@@ -7,6 +7,8 @@ from app.utils.interactive_login import login_with_qrcode
 from auth.new_login import LoginState
 from auth.new_qrcode_login import NewQRCodeLogin, QRCodeLoginStatus
 
+TEST_DOMAIN = "auth-session"
+
 
 class FakeResponse:
     """

--- a/test/auth/util.py
+++ b/test/auth/util.py
@@ -2,6 +2,8 @@ import unittest
 
 from auth import ServerError, getVPNUrl, getOrdinaryUrl
 
+TEST_DOMAIN = "auth-session"
+
 
 class TestAuthUtils(unittest.TestCase):
     def test_servererror(self):

--- a/test/ci/check_test_contract.py
+++ b/test/ci/check_test_contract.py
@@ -12,6 +12,7 @@ from typing import Iterable
 
 from test.ci.shards import (
     DOMAIN_DEFINITIONS,
+    MINIMUM_REGRESSION_MODULES,
     REPOSITORY_ROOT,
     SHARDS,
     TEST_ROOT,
@@ -20,7 +21,7 @@ from test.ci.shards import (
     module_name,
     regression_modules,
     scan_test_modules,
-    shards_for_test_root,
+    shards_for_records,
 )
 
 
@@ -116,13 +117,14 @@ def contract_errors(
     shards: tuple[Shard, ...] | None = None,
     repository_root: Path = REPOSITORY_ROOT,
     product_modules: set[str] | None = None,
+    minimum_regression_modules: int = MINIMUM_REGRESSION_MODULES,
 ) -> list[str]:
     """Collect deterministic inventory, marker, path, and syntax violations."""
 
     test_root = repository_root / "test"
-    if shards is None:
-        shards = shards_for_test_root(test_root)
     records = scan_test_modules(test_root)
+    if shards is None:
+        shards = shards_for_records(records)
     errors: list[str] = []
     domains = tuple((shard.id, shard.name) for shard in shards)
     ids = [shard.id for shard in shards]
@@ -174,6 +176,11 @@ def contract_errors(
     regression_targets = regression_modules(records)
     if not regression_targets:
         errors.append("no regression test modules are marked")
+    elif len(regression_targets) < minimum_regression_modules:
+        errors.append(
+            "too few regression test modules are marked: "
+            f"{len(regression_targets)} (minimum {minimum_regression_modules})"
+        )
     for module in regression_targets:
         if module not in declared:
             errors.append(f"regression module is not in a domain: {module}")
@@ -192,7 +199,7 @@ def render_inventory_markdown(
 
     records = scan_test_modules(test_root)
     if shards is None:
-        shards = shards_for_test_root(test_root)
+        shards = shards_for_records(records)
     if product_modules is None:
         product_modules = {record.module for record in records}
     if regression_targets is None:
@@ -230,9 +237,10 @@ def render_domain_matrix_json(
 
 
 def _text_output(test_root: Path = TEST_ROOT) -> str:
-    shards = shards_for_test_root(test_root)
+    records = scan_test_modules(test_root)
+    shards = shards_for_records(records)
     return (
-        f"OK: {len(product_test_modules(test_root))} product test modules are "
+        f"OK: {len(records)} product test modules are "
         f"covered by {len(shards)} domains."
     )
 

--- a/test/ci/check_test_contract.py
+++ b/test/ci/check_test_contract.py
@@ -1,43 +1,39 @@
-"""Validate that product tests are registered in exactly one test domain."""
+"""Validate that product tests declare exactly one known test domain."""
 
 from __future__ import annotations
 
+import argparse
 import ast
+import json
 import re
 import sys
 from pathlib import Path
+from typing import Iterable
 
-from test.ci.shards import REGRESSION_MODULES, SHARDS, Shard
-
-
-REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
-TEST_ROOT = REPOSITORY_ROOT / "test"
-DOMAIN_ID_PATTERN = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
-EXPECTED_DOMAINS = (
-    ("ai", "AI core and features"),
-    ("qt-ui", "Qt and desktop UI"),
-    ("notification-crawler", "Notifications and crawler"),
-    ("auth-session", "Authentication and sessions"),
-    ("schedule", "Schedule"),
+from test.ci.shards import (
+    DOMAIN_DEFINITIONS,
+    REPOSITORY_ROOT,
+    SHARDS,
+    TEST_ROOT,
+    Shard,
+    TestModule,
+    module_name,
+    regression_modules,
+    scan_test_modules,
+    shards_for_test_root,
 )
 
 
-def module_name(path: Path, test_root: Path = TEST_ROOT) -> str:
-    """Convert a Python path below ``test_root`` into a ``test.*`` import."""
-
-    relative = path.relative_to(test_root).with_suffix("")
-    return "test." + ".".join(relative.parts)
+DOMAIN_ID_PATTERN = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+EXPECTED_DOMAINS = tuple(
+    (definition.id, definition.name) for definition in DOMAIN_DEFINITIONS
+)
 
 
 def product_test_modules(test_root: Path = TEST_ROOT) -> set[str]:
-    """Discover product tests, excluding package markers and ``test/ci``."""
+    """Discover product-test import names without importing test modules."""
 
-    return {
-        module_name(path, test_root)
-        for path in test_root.rglob("*.py")
-        if path.name != "__init__.py"
-        and path.relative_to(test_root).parts[0] != "ci"
-    }
+    return {record.module for record in scan_test_modules(test_root)}
 
 
 def owned_modules(shards: tuple[Shard, ...] = SHARDS) -> dict[str, list[str]]:
@@ -53,11 +49,12 @@ def owned_modules(shards: tuple[Shard, ...] = SHARDS) -> dict[str, list[str]]:
 def inventory_problems(
     shards: tuple[Shard, ...] = SHARDS,
     product_modules: set[str] | None = None,
+    test_root: Path = TEST_ROOT,
 ) -> tuple[set[str], dict[str, list[str]], set[str]]:
     """Return missing, multiply owned, and unexpected declared modules."""
 
     if product_modules is None:
-        product_modules = product_test_modules()
+        product_modules = product_test_modules(test_root)
     owners = owned_modules(shards)
     declared = set(owners)
     missing = product_modules - declared
@@ -70,13 +67,62 @@ def inventory_problems(
     return missing, duplicates, unexpected
 
 
+def _marker_errors(records: Iterable[TestModule], known_domains: set[str]) -> list[str]:
+    """Return deterministic errors for every malformed module marker."""
+
+    errors: list[str] = []
+    for record in records:
+        if record.parse_error is not None:
+            errors.append(f"cannot parse {record.module}: {record.parse_error}")
+            continue
+        if not record.marker_values:
+            errors.append(f"missing TEST_DOMAIN marker: {record.module}")
+            continue
+        if len(record.marker_values) > 1:
+            errors.append(f"duplicate TEST_DOMAIN marker: {record.module}")
+            continue
+        value = record.marker_values[0]
+        if not isinstance(value, str):
+            errors.append(
+                f"TEST_DOMAIN must be a string: {record.module} (got {value!r})"
+            )
+            continue
+        if not DOMAIN_ID_PATTERN.fullmatch(value):
+            errors.append(f"invalid TEST_DOMAIN marker: {record.module} ({value!r})")
+        elif value not in known_domains:
+            errors.append(f"unknown TEST_DOMAIN domain: {record.module} ({value})")
+    return errors
+
+
+def _regression_marker_errors(records: Iterable[TestModule]) -> list[str]:
+    """Validate optional top-level ``TEST_REGRESSION`` boolean markers."""
+
+    errors: list[str] = []
+    for record in records:
+        if record.parse_error is not None or not record.regression_values:
+            continue
+        if len(record.regression_values) > 1:
+            errors.append(f"duplicate TEST_REGRESSION marker: {record.module}")
+            continue
+        value = record.regression_values[0]
+        if not isinstance(value, bool):
+            errors.append(
+                f"TEST_REGRESSION must be a boolean: {record.module} (got {value!r})"
+            )
+    return errors
+
+
 def contract_errors(
-    shards: tuple[Shard, ...] = SHARDS,
+    shards: tuple[Shard, ...] | None = None,
     repository_root: Path = REPOSITORY_ROOT,
     product_modules: set[str] | None = None,
 ) -> list[str]:
-    """Collect every deterministic inventory, path and syntax violation."""
+    """Collect deterministic inventory, marker, path, and syntax violations."""
 
+    test_root = repository_root / "test"
+    if shards is None:
+        shards = shards_for_test_root(test_root)
+    records = scan_test_modules(test_root)
     errors: list[str] = []
     domains = tuple((shard.id, shard.name) for shard in shards)
     ids = [shard.id for shard in shards]
@@ -93,9 +139,13 @@ def contract_errors(
         if not DOMAIN_ID_PATTERN.fullmatch(shard.id):
             errors.append(f"invalid domain ID: {shard.id!r}")
 
+    errors.extend(_marker_errors(records, {shard.id for shard in DOMAIN_DEFINITIONS}))
+    errors.extend(_regression_marker_errors(records))
     if product_modules is None:
-        product_modules = product_test_modules(repository_root / "test")
-    missing, duplicates, unexpected = inventory_problems(shards, product_modules)
+        product_modules = {record.module for record in records}
+    missing, duplicates, unexpected = inventory_problems(
+        shards, product_modules, test_root
+    )
     errors.extend(f"missing test module: {module}" for module in sorted(missing))
     errors.extend(
         f"duplicate test module: {module} ({','.join(owners)})"
@@ -113,27 +163,100 @@ def contract_errors(
             continue
         try:
             ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
-        except (OSError, SyntaxError) as error:
-            errors.append(f"cannot parse {module}: {error}")
+        except (OSError, SyntaxError, UnicodeError) as error:
+            # Product files are normally parsed by ``scan_test_modules``; this
+            # second check also covers an explicitly declared file under the
+            # excluded ``test/ci`` tree or a synthetic contract fixture.
+            parse_error = f"cannot parse {module}: {error}"
+            if parse_error not in errors:
+                errors.append(parse_error)
 
-    for module in REGRESSION_MODULES:
+    regression_targets = regression_modules(records)
+    if not regression_targets:
+        errors.append("no regression test modules are marked")
+    for module in regression_targets:
         if module not in declared:
             errors.append(f"regression module is not in a domain: {module}")
-    if len(REGRESSION_MODULES) != len(set(REGRESSION_MODULES)):
+    if len(regression_targets) != len(set(regression_targets)):
         errors.append("duplicate regression module")
     return errors
 
 
-def main() -> int:
+def render_inventory_markdown(
+    shards: tuple[Shard, ...] | None = None,
+    product_modules: set[str] | None = None,
+    regression_targets: tuple[str, ...] | None = None,
+    test_root: Path = TEST_ROOT,
+) -> str:
+    """Render the current runtime inventory for humans and documentation."""
+
+    records = scan_test_modules(test_root)
+    if shards is None:
+        shards = shards_for_test_root(test_root)
+    if product_modules is None:
+        product_modules = {record.module for record in records}
+    if regression_targets is None:
+        regression_targets = regression_modules(records)
+    lines = [
+        f"## Test inventory: {len(product_modules)} product test modules",
+        f"Covered by {len(shards)} domains.",
+        "",
+        "| Domain ID | Display name | Module count | Modules |",
+        "|---|---|---:|---|",
+    ]
+    for shard in shards:
+        modules = ", ".join(f"`{module}`" for module in shard.modules) or "_none_"
+        lines.append(
+            f"| `{shard.id}` | {shard.name} | {len(shard.modules)} | {modules} |"
+        )
+    lines.extend(("", "### Regression modules", ""))
+    if regression_targets:
+        lines.extend(f"- `{module}`" for module in regression_targets)
+    else:
+        lines.append("_none_")
+    return "\n".join(lines) + "\n"
+
+
+def render_domain_matrix_json(
+    definitions: tuple[Shard, ...] = DOMAIN_DEFINITIONS,
+) -> str:
+    """Render the validated domain definitions for GitHub Actions matrices."""
+
+    return json.dumps(
+        [{"id": definition.id, "name": definition.name} for definition in definitions],
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+
+
+def _text_output(test_root: Path = TEST_ROOT) -> str:
+    shards = shards_for_test_root(test_root)
+    return (
+        f"OK: {len(product_test_modules(test_root))} product test modules are "
+        f"covered by {len(shards)} domains."
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--format",
+        choices=("text", "markdown", "domain-json"),
+        default="text",
+        help="output format after the contract passes",
+    )
+    args = parser.parse_args(argv)
     errors = contract_errors()
     if errors:
         for error in errors:
             print(f"ERROR: {error}", file=sys.stderr)
         return 1
-    print(
-        f"OK: {len(product_test_modules())} product test modules are covered by "
-        f"{len(SHARDS)} domains."
-    )
+    if args.format == "markdown":
+        print(render_inventory_markdown(), end="")
+    elif args.format == "domain-json":
+        print(render_domain_matrix_json())
+    else:
+        print(_text_output())
     return 0
 
 

--- a/test/ci/run_test_regressions.py
+++ b/test/ci/run_test_regressions.py
@@ -1,0 +1,65 @@
+"""Run every product test module marked for historical regression coverage."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import unittest
+from collections.abc import Sequence
+
+from test.ci.shards import regression_modules
+
+
+def build_suite(modules: Sequence[str] | None = None) -> unittest.TestSuite:
+    """Build a suite from the AST-derived regression module inventory."""
+
+    if modules is None:
+        modules = regression_modules()
+    if not modules:
+        raise ValueError("no regression test modules are marked")
+    loader = unittest.defaultTestLoader
+    suite = unittest.TestSuite(
+        loader.loadTestsFromName(module) for module in modules
+    )
+    if suite.countTestCases() == 0:
+        raise ValueError("regression test inventory contains no test cases")
+    return suite
+
+
+def finish_result(
+    result: unittest.TestResult, *, hard_exit_on_success: bool
+) -> int:
+    """Return the result, optionally bypassing problematic Qt teardown."""
+
+    if not result.wasSuccessful():
+        return 1
+    if hard_exit_on_success:
+        sys.stdout.flush()
+        sys.stderr.flush()
+        os._exit(0)
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--hard-exit-on-success",
+        action="store_true",
+        help="flush logs and skip interpreter teardown after a successful suite",
+    )
+    args = parser.parse_args(argv)
+    modules = regression_modules()
+    if not modules:
+        raise ValueError("no regression test modules are marked")
+    print("Regression modules: " + ", ".join(modules), flush=True)
+    print(
+        "Command: python -m unittest -v " + " ".join(modules),
+        flush=True,
+    )
+    result = unittest.TextTestRunner(verbosity=2).run(build_suite(modules))
+    return finish_result(result, hard_exit_on_success=args.hard_exit_on_success)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/ci/run_test_regressions.py
+++ b/test/ci/run_test_regressions.py
@@ -50,8 +50,6 @@ def main(argv: Sequence[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
     modules = regression_modules()
-    if not modules:
-        raise ValueError("no regression test modules are marked")
     print("Regression modules: " + ", ".join(modules), flush=True)
     print(
         "Command: python -m unittest -v " + " ".join(modules),

--- a/test/ci/shards.py
+++ b/test/ci/shards.py
@@ -17,6 +17,11 @@ from typing import Any, Iterator
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 TEST_ROOT = REPOSITORY_ROOT / "test"
 
+# Keep a meaningful floor on historical regression coverage.  New regression
+# modules are discovered from their own markers; changing this value is an
+# intentional decision to reduce the protected bug surface.
+MINIMUM_REGRESSION_MODULES = 6
+
 
 @dataclass(frozen=True)
 class Shard:
@@ -139,6 +144,27 @@ def _marker_values(
             if bound_name == marker_name:
                 self.values.append(None)
 
+        def _visit_scope_declarations(self, body: list[ast.stmt]) -> None:
+            """Reject global/nonlocal marker declarations in skipped scopes."""
+
+            # Function and class bodies are intentionally skipped below so
+            # ordinary local assignments do not look like module metadata.
+            # ``global`` is an exception: it can write the module binding, and
+            # ``nonlocal`` is similarly surprising for a marker declaration.
+            for statement in body:
+                for node in ast.walk(statement):
+                    if isinstance(node, (ast.Global, ast.Nonlocal)):
+                        if marker_name in node.names:
+                            self.values.append(None)
+
+        def visit_Global(self, node: ast.Global) -> None:
+            if marker_name in node.names:
+                self.values.append(None)
+
+        def visit_Nonlocal(self, node: ast.Nonlocal) -> None:
+            if marker_name in node.names:
+                self.values.append(None)
+
         def visit_ExceptHandler(self, node: ast.ExceptHandler) -> None:
             if node.name == marker_name:
                 self.values.append(None)
@@ -177,9 +203,11 @@ def _marker_values(
 
         def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
             self._visit_definition_header(node)
+            self._visit_scope_declarations(node.body)
 
         def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
             self._visit_definition_header(node)
+            self._visit_scope_declarations(node.body)
 
         def visit_Lambda(self, node: ast.Lambda) -> None:
             for default in (*node.args.defaults, *node.args.kw_defaults):
@@ -195,6 +223,7 @@ def _marker_values(
                 self.visit(base)
             for keyword in node.keywords:
                 self.visit(keyword.value)
+            self._visit_scope_declarations(node.body)
 
     visitor = MarkerBindingVisitor()
     visitor.read_direct_declarations()
@@ -224,11 +253,11 @@ def scan_test_modules(test_root: Path = TEST_ROOT) -> tuple[TestModule, ...]:
     return tuple(records)
 
 
-def shards_for_test_root(test_root: Path = TEST_ROOT) -> tuple[Shard, ...]:
-    """Build domain shards from valid markers below ``test_root``."""
+def shards_for_records(records: tuple[TestModule, ...]) -> tuple[Shard, ...]:
+    """Build domain shards from a previously scanned record collection."""
 
     modules_by_domain = {definition.id: [] for definition in DOMAIN_DEFINITIONS}
-    for record in scan_test_modules(test_root):
+    for record in records:
         if len(record.marker_values) != 1:
             continue
         domain = record.marker_values[0]
@@ -238,6 +267,12 @@ def shards_for_test_root(test_root: Path = TEST_ROOT) -> tuple[Shard, ...]:
         Shard(definition.id, definition.name, tuple(modules_by_domain[definition.id]))
         for definition in DOMAIN_DEFINITIONS
     )
+
+
+def shards_for_test_root(test_root: Path = TEST_ROOT) -> tuple[Shard, ...]:
+    """Build domain shards from valid markers below ``test_root``."""
+
+    return shards_for_records(scan_test_modules(test_root))
 
 
 def regression_modules(
@@ -266,14 +301,15 @@ def regression_modules_for_test_root(test_root: Path = TEST_ROOT) -> tuple[str, 
     return regression_modules(scan_test_modules(test_root))
 
 
-# The runner imports this value directly.  It is generated once per process,
-# while the contract checker can rescan an arbitrary root for isolated tests.
-SHARDS: tuple[Shard, ...] = shards_for_test_root()
+# The runner imports these values directly.  Keep one default AST scan for the
+# two generated views; callers checking another checkout can rescan explicitly.
+_DEFAULT_TEST_MODULES = scan_test_modules()
+SHARDS: tuple[Shard, ...] = shards_for_records(_DEFAULT_TEST_MODULES)
 
 # Backward-compatible generated view for callers that imported the former
 # hand-maintained constant.  New code should call ``regression_modules()`` so
 # it can rescan an alternate test root when needed.
-REGRESSION_MODULES: tuple[str, ...] = regression_modules()
+REGRESSION_MODULES: tuple[str, ...] = regression_modules(_DEFAULT_TEST_MODULES)
 
 
 def get_shard(shard_id: str) -> Shard:

--- a/test/ci/shards.py
+++ b/test/ci/shards.py
@@ -1,8 +1,21 @@
-"""The single source of truth for pull-request test domains."""
+"""Discover pull-request test domains from metadata in each test module.
+
+The domain definitions in this module are intentionally stable.  Product test
+files own their membership through a top-level ``TEST_DOMAIN`` assignment; the
+scanner below reads that assignment with :mod:`ast` so checking the inventory
+never imports (or executes) a product test module.
+"""
 
 from __future__ import annotations
 
+import ast
 from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterator
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+TEST_ROOT = REPOSITORY_ROOT / "test"
 
 
 @dataclass(frozen=True)
@@ -11,76 +24,256 @@ class Shard:
 
     id: str
     name: str
-    modules: tuple[str, ...]
+    # ``modules`` remains public for runners and synthetic contract tests.  It
+    # is populated automatically for the real ``SHARDS`` value below.
+    modules: tuple[str, ...] = ()
 
 
-SHARDS: tuple[Shard, ...] = (
-    Shard(
-        "ai",
-        "AI core and features",
-        (
-            "test.ai_assistant.test_ai_core",
-            "test.ai_assistant.test_ai_features",
-        ),
-    ),
-    Shard(
-        "qt-ui",
-        "Qt and desktop UI",
-        (
-            "test.app.test_campus_job",
-            "test.app.test_campus_pages",
-            "test.app.test_campus_registration",
-            "test.app.test_ctrl_c",
-            "test.app.test_notice_search_ui",
-            "test.app.test_notice_thread",
-            "test.library.test_booking_parse",
-        ),
-    ),
-    Shard(
-        "notification-crawler",
-        "Notifications and crawler",
-        (
-            "test.notification.test_notification_sources",
-            "test.test_crawler_challenge",
-        ),
-    ),
-    Shard(
-        "auth-session",
-        "Authentication and sessions",
-        (
-            "test.auth.login",
-            "test.auth.test_qrcode_login",
-            "test.auth.util",
-            "test.fitness.test_session",
-            "test.hello.test_session",
-            "test.sessions.session_manager",
-        ),
-    ),
-    Shard(
-        "schedule",
-        "Schedule",
-        (
-            "test.fitness.test_score_zero",
-            "test.fitness.test_years",
-            "test.hello.test_profile",
-            "test.jwxt.test_calendar_api",
-            "test.jwxt.test_calendar_week",
-            "test.jwxt.test_school_course_headers",
-            "test.schedule.test_lesson",
-            "test.schedule.test_schedule",
-        ),
-    ),
+@dataclass(frozen=True)
+class TestModule:
+    """AST-level metadata for one product test file."""
+
+    module: str
+    path: Path
+    marker_values: tuple[Any, ...] = ()
+    parse_error: str | None = None
+    regression_values: tuple[Any, ...] = ()
+
+
+# Keep this tuple as the only source of stable domain IDs, display names, and
+# their matrix order.  Adding a test to an existing domain does not touch it.
+DOMAIN_DEFINITIONS: tuple[Shard, ...] = (
+    Shard("ai", "AI core and features"),
+    Shard("qt-ui", "Qt and desktop UI"),
+    Shard("notification-crawler", "Notifications and crawler"),
+    Shard("auth-session", "Authentication and sessions"),
+    Shard("schedule", "Schedule"),
 )
 
 
-REGRESSION_MODULES: tuple[str, ...] = (
-    "test.ai_assistant.test_ai_features",
-    "test.app.test_notice_search_ui",
-    "test.notification.test_notification_sources",
-    "test.app.test_notice_thread",
-    "test.schedule.test_lesson",
-    "test.test_crawler_challenge",
-)
+def _is_product_test(path: Path, test_root: Path) -> bool:
+    """Return whether ``path`` belongs to the product-test inventory."""
+
+    relative = path.relative_to(test_root)
+    return (
+        path.suffix == ".py"
+        and path.name != "__init__.py"
+        and (not relative.parts or relative.parts[0] != "ci")
+    )
+
+
+def iter_product_test_files(test_root: Path = TEST_ROOT) -> Iterator[Path]:
+    """Yield product test files in deterministic relative-path order."""
+
+    if not test_root.is_dir():
+        return
+    paths = (
+        path
+        for path in test_root.rglob("*.py")
+        if _is_product_test(path, test_root)
+    )
+    yield from sorted(paths, key=lambda path: path.relative_to(test_root).as_posix())
+
+
+def module_name(path: Path, test_root: Path = TEST_ROOT) -> str:
+    """Convert a Python path below ``test_root`` into a ``test.*`` import."""
+
+    relative = path.relative_to(test_root).with_suffix("")
+    return "test." + ".".join(relative.parts)
+
+
+def _marker_values(
+    tree: ast.Module, marker_name: str = "TEST_DOMAIN"
+) -> tuple[Any, ...]:
+    """Read one direct marker declaration and reject every other binding.
+
+    Exactly one direct, top-level literal assignment is valid.  Writes inside
+    module-level control flow, imports, loops, context managers, exception
+    handlers, named expressions, augmented assignments, deletions, chained
+    assignments, and dynamic values produce invalid sentinels.  Function and
+    class bodies are separate scopes and are not metadata declarations.
+    """
+
+    class MarkerBindingVisitor(ast.NodeVisitor):
+        def __init__(self) -> None:
+            self.values: list[Any] = []
+            self.direct_target_ids: set[int] = set()
+
+        def read_direct_declarations(self) -> None:
+            for statement in tree.body:
+                targets: tuple[ast.expr, ...]
+                value: ast.expr | None
+                if isinstance(statement, ast.Assign):
+                    targets = tuple(statement.targets)
+                    value = statement.value
+                elif isinstance(statement, ast.AnnAssign):
+                    targets = (statement.target,)
+                    value = statement.value
+                else:
+                    continue
+                marker_targets = [
+                    target
+                    for target in targets
+                    if isinstance(target, ast.Name) and target.id == marker_name
+                ]
+                if not marker_targets:
+                    continue
+                self.direct_target_ids.update(id(target) for target in marker_targets)
+                if len(targets) != 1 or not isinstance(targets[0], ast.Name):
+                    self.values.append(None)
+                elif isinstance(value, ast.Constant):
+                    self.values.append(value.value)
+                else:
+                    self.values.append(None)
+
+        def visit_Name(self, node: ast.Name) -> None:
+            if (
+                node.id == marker_name
+                and isinstance(node.ctx, (ast.Store, ast.Del))
+                and id(node) not in self.direct_target_ids
+            ):
+                self.values.append(None)
+
+        def visit_alias(self, node: ast.alias) -> None:
+            bound_name = node.asname or node.name.split(".", 1)[0]
+            if bound_name == marker_name:
+                self.values.append(None)
+
+        def visit_ExceptHandler(self, node: ast.ExceptHandler) -> None:
+            if node.name == marker_name:
+                self.values.append(None)
+            if node.type is not None:
+                self.visit(node.type)
+            for statement in node.body:
+                self.visit(statement)
+
+        def visit_MatchAs(self, node: ast.MatchAs) -> None:
+            if node.name == marker_name:
+                self.values.append(None)
+            if node.pattern is not None:
+                self.visit(node.pattern)
+
+        def visit_MatchStar(self, node: ast.MatchStar) -> None:
+            if node.name == marker_name:
+                self.values.append(None)
+
+        def visit_MatchMapping(self, node: ast.MatchMapping) -> None:
+            if node.rest == marker_name:
+                self.values.append(None)
+            self.generic_visit(node)
+
+        def _visit_definition_header(
+            self, node: ast.FunctionDef | ast.AsyncFunctionDef
+        ) -> None:
+            if node.name == marker_name:
+                self.values.append(None)
+            for decorator in node.decorator_list:
+                self.visit(decorator)
+            for default in (*node.args.defaults, *node.args.kw_defaults):
+                if default is not None:
+                    self.visit(default)
+            if node.returns is not None:
+                self.visit(node.returns)
+
+        def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+            self._visit_definition_header(node)
+
+        def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+            self._visit_definition_header(node)
+
+        def visit_Lambda(self, node: ast.Lambda) -> None:
+            for default in (*node.args.defaults, *node.args.kw_defaults):
+                if default is not None:
+                    self.visit(default)
+
+        def visit_ClassDef(self, node: ast.ClassDef) -> None:
+            if node.name == marker_name:
+                self.values.append(None)
+            for decorator in node.decorator_list:
+                self.visit(decorator)
+            for base in node.bases:
+                self.visit(base)
+            for keyword in node.keywords:
+                self.visit(keyword.value)
+
+    visitor = MarkerBindingVisitor()
+    visitor.read_direct_declarations()
+    visitor.visit(tree)
+    return tuple(visitor.values)
+
+
+def scan_test_modules(test_root: Path = TEST_ROOT) -> tuple[TestModule, ...]:
+    """Parse product tests and return their marker metadata without imports."""
+
+    records: list[TestModule] = []
+    for path in iter_product_test_files(test_root):
+        module = module_name(path, test_root)
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        except (OSError, SyntaxError, UnicodeError) as error:
+            records.append(TestModule(module, path, parse_error=str(error)))
+        else:
+            records.append(
+                TestModule(
+                    module,
+                    path,
+                    marker_values=_marker_values(tree),
+                    regression_values=_marker_values(tree, "TEST_REGRESSION"),
+                )
+            )
+    return tuple(records)
+
+
+def shards_for_test_root(test_root: Path = TEST_ROOT) -> tuple[Shard, ...]:
+    """Build domain shards from valid markers below ``test_root``."""
+
+    modules_by_domain = {definition.id: [] for definition in DOMAIN_DEFINITIONS}
+    for record in scan_test_modules(test_root):
+        if len(record.marker_values) != 1:
+            continue
+        domain = record.marker_values[0]
+        if isinstance(domain, str) and domain in modules_by_domain:
+            modules_by_domain[domain].append(record.module)
+    return tuple(
+        Shard(definition.id, definition.name, tuple(modules_by_domain[definition.id]))
+        for definition in DOMAIN_DEFINITIONS
+    )
+
+
+def regression_modules(
+    records: tuple[TestModule, ...] | None = None,
+) -> tuple[str, ...]:
+    """Return modules marked for historical regression coverage.
+
+    The default scan is intentionally AST-only.  A caller checking another
+    checkout can pass records from :func:`scan_test_modules` or use
+    :func:`regression_modules_for_test_root`.
+    """
+
+    if records is None:
+        records = scan_test_modules()
+    return tuple(
+        record.module
+        for record in records
+        if len(record.regression_values) == 1
+        and record.regression_values[0] is True
+    )
+
+
+def regression_modules_for_test_root(test_root: Path = TEST_ROOT) -> tuple[str, ...]:
+    """Return marked regression modules discovered below ``test_root``."""
+
+    return regression_modules(scan_test_modules(test_root))
+
+
+# The runner imports this value directly.  It is generated once per process,
+# while the contract checker can rescan an arbitrary root for isolated tests.
+SHARDS: tuple[Shard, ...] = shards_for_test_root()
+
+# Backward-compatible generated view for callers that imported the former
+# hand-maintained constant.  New code should call ``regression_modules()`` so
+# it can rescan an alternate test root when needed.
+REGRESSION_MODULES: tuple[str, ...] = regression_modules()
 
 
 def get_shard(shard_id: str) -> Shard:

--- a/test/ci/test_pr_workflow.py
+++ b/test/ci/test_pr_workflow.py
@@ -479,6 +479,46 @@ class TestInventoryContract(unittest.TestCase):
                 errors,
             )
 
+    def test_global_and_nonlocal_marker_declarations_are_rejected(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            repository_root = Path(temporary_directory)
+            test_root = repository_root / "test"
+            sources = {
+                "global_marker.py": (
+                    'TEST_DOMAIN = "ai"\n'
+                    "def configure():\n"
+                    "    global TEST_DOMAIN\n"
+                    '    TEST_DOMAIN = "schedule"\n'
+                ),
+                "nested_nonlocal.py": (
+                    'TEST_DOMAIN = "ai"\n'
+                    "def configure():\n"
+                    '    value = "outer"\n'
+                    "    def nested():\n"
+                    "        nonlocal TEST_DOMAIN\n"
+                    '        TEST_DOMAIN = "schedule"\n'
+                ),
+            }
+            for relative, source in sources.items():
+                path = test_root / relative
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(source, encoding="utf-8")
+
+            records = scan_test_modules(test_root)
+            errors = contract_errors(
+                repository_root=repository_root,
+                minimum_regression_modules=0,
+            )
+
+            self.assertIn(None, records[0].marker_values)
+            self.assertIn(None, records[1].marker_values)
+            self.assertIn(
+                "duplicate TEST_DOMAIN marker: test.global_marker", errors
+            )
+            self.assertIn(
+                "duplicate TEST_DOMAIN marker: test.nested_nonlocal", errors
+            )
+
     def test_malformed_markers_are_rejected_without_evaluation(self) -> None:
         with TemporaryDirectory() as temporary_directory:
             repository_root = Path(temporary_directory)
@@ -777,7 +817,10 @@ class TestInventoryContract(unittest.TestCase):
             )
             self.assertEqual(
                 [],
-                contract_errors(repository_root=test_root.parent),
+                contract_errors(
+                    repository_root=test_root.parent,
+                    minimum_regression_modules=1,
+                ),
             )
 
     def test_added_product_module_is_missing(self) -> None:
@@ -868,6 +911,29 @@ class TestInventoryContract(unittest.TestCase):
             errors = contract_errors(repository_root=repository_root)
 
             self.assertIn("no regression test modules are marked", errors)
+
+    def test_contract_enforces_the_regression_module_floor(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            repository_root = Path(temporary_directory)
+            test_root = repository_root / "test"
+            for domain in DOMAIN_DEFINITIONS:
+                path = test_root / domain.id / "test_existing.py"
+                path.parent.mkdir(parents=True, exist_ok=True)
+                marker = "\nTEST_REGRESSION = True" if domain.id == "ai" else ""
+                path.write_text(
+                    f'TEST_DOMAIN = "{domain.id}"{marker}\n',
+                    encoding="utf-8",
+                )
+
+            errors = contract_errors(
+                repository_root=repository_root,
+                minimum_regression_modules=2,
+            )
+
+            self.assertIn(
+                "too few regression test modules are marked: 1 (minimum 2)",
+                errors,
+            )
 
     def test_regressions_are_unique_and_owned(self) -> None:
         modules = regression_modules()
@@ -1093,6 +1159,21 @@ class TestWorkflowContract(unittest.TestCase):
         self.assertTrue(TESTING_DOC_PATH.is_file())
         self.assertTrue(NOTIFICATION_DOC_PATH.is_file())
         self.assertTrue(PR_TEMPLATE_PATH.is_file())
+
+    def test_domain_export_propagates_contract_command_failures(self) -> None:
+        workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+        step = named_step_section(
+            workflow, "test-contract", "Export validated test domains"
+        )
+        self.assertIn(
+            "run: |\n"
+            "          domains=$(python -m test.ci.check_test_contract --format domain-json)\n"
+            "          echo \"domains=$domains\" >> \"$GITHUB_OUTPUT\"",
+            step,
+        )
+        self.assertNotIn(
+            'run: echo "domains=$(python -m test.ci.check_test_contract', step
+        )
 
     def test_triggers_permissions_and_concurrency_are_bounded(self) -> None:
         workflow = WORKFLOW_PATH.read_text(encoding="utf-8")

--- a/test/ci/test_pr_workflow.py
+++ b/test/ci/test_pr_workflow.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import subprocess
@@ -21,8 +22,14 @@ from test.ci.check_test_contract import (
     module_name,
     owned_modules,
     product_test_modules,
+    render_domain_matrix_json,
+    render_inventory_markdown,
 )
-from test.ci import run_test_shard
+from test.ci import run_test_regressions, run_test_shard
+from test.ci.run_test_regressions import (
+    build_suite as build_regression_suite,
+    finish_result as finish_regression_result,
+)
 from test.ci.run_test_shard import (
     build_suite,
     canonical_machine,
@@ -30,11 +37,21 @@ from test.ci.run_test_shard import (
     verify_imports,
     verify_machine,
 )
-from test.ci.shards import REGRESSION_MODULES, SHARDS, Shard, get_shard
+from test.ci.shards import (
+    DOMAIN_DEFINITIONS,
+    SHARDS,
+    Shard,
+    get_shard,
+    regression_modules,
+    regression_modules_for_test_root,
+    scan_test_modules,
+    shards_for_test_root,
+)
 
 
 WORKFLOW_PATH = REPOSITORY_ROOT / ".github" / "workflows" / "pr-tests.yml"
 TESTING_DOC_PATH = REPOSITORY_ROOT / "docs" / "development" / "testing.md"
+NOTIFICATION_DOC_PATH = REPOSITORY_ROOT / "docs" / "development" / "notification.md"
 PR_TEMPLATE_PATH = REPOSITORY_ROOT / ".github" / "pull_request_template.md"
 
 XDG_RUNNER_TEMP_ENV = (
@@ -53,12 +70,8 @@ HOSTED_PLATFORMS = (
     ("macos-intel-py312", "macos-15-intel", "3.12", "x86_64"),
 )
 
-EXPECTED_DOMAINS = (
-    ("ai", "AI core and features"),
-    ("qt-ui", "Qt and desktop UI"),
-    ("notification-crawler", "Notifications and crawler"),
-    ("auth-session", "Authentication and sessions"),
-    ("schedule", "Schedule"),
+EXPECTED_DOMAINS = tuple(
+    (definition.id, definition.name) for definition in DOMAIN_DEFINITIONS
 )
 
 ARM_IMPORTS = (
@@ -78,6 +91,8 @@ ARM_PINS = (
     "darkdetect==0.8.0",
     "xcffib==1.12.0",
 )
+
+DOMAIN_MATRIX_EXPRESSION = "${{ fromJSON(needs.test-contract.outputs.domains) }}"
 
 
 class TestLocalTestRunner(unittest.TestCase):
@@ -261,8 +276,16 @@ def matrix_records(
     return tuple(records)
 
 
+def matrix_axis_expression(workflow: str, job_id: str, axis: str) -> str | None:
+    """Extract a scalar GitHub Actions expression from a matrix axis."""
+
+    section = job_section(workflow, job_id)
+    match = re.search(rf"(?m)^        {re.escape(axis)}: (.+)$", section)
+    return match.group(1).strip() if match else None
+
+
 def matrix_contract_errors(workflow: str) -> list[str]:
-    """Return exact job, matrix-member, count, and display-name drift."""
+    """Return exact job, platform, matrix-expression, and display-name drift."""
 
     errors: list[str] = []
     jobs_section = workflow.split("jobs:\n", 1)[1] if "jobs:\n" in workflow else ""
@@ -283,23 +306,28 @@ def matrix_contract_errors(workflow: str) -> list[str]:
         }
         for platform_id, runner, python_version, machine in HOSTED_PLATFORMS
     )
-    expected_domains = tuple(
-        {"id": shard.id, "name": shard.name} for shard in SHARDS
-    )
     hosted_platforms = matrix_records(workflow, "test-shards", "platform")
-    hosted_domains = matrix_records(workflow, "test-shards", "domain")
-    arm_domains = matrix_records(workflow, "linux-arm-shards", "domain")
+    hosted_domain_expression = matrix_axis_expression(
+        workflow, "test-shards", "domain"
+    )
+    arm_domain_expression = matrix_axis_expression(
+        workflow, "linux-arm-shards", "domain"
+    )
     if job_ids != expected_job_ids:
         errors.append(f"unexpected workflow jobs: {job_ids!r}")
     if hosted_platforms != expected_platforms:
         errors.append(f"unexpected hosted platforms: {hosted_platforms!r}")
-    if hosted_domains != expected_domains:
-        errors.append(f"unexpected hosted domains: {hosted_domains!r}")
-    if arm_domains != expected_domains:
-        errors.append(f"unexpected QEMU domains: {arm_domains!r}")
-    primary_checks = len(hosted_platforms) * len(hosted_domains) + len(arm_domains)
-    if primary_checks != 30 or primary_checks + 3 != 33:
-        errors.append(f"unexpected check count: primary={primary_checks}")
+    if hosted_domain_expression != DOMAIN_MATRIX_EXPRESSION:
+        errors.append(
+            f"unexpected hosted domain matrix: {hosted_domain_expression!r}"
+        )
+    if arm_domain_expression != DOMAIN_MATRIX_EXPRESSION:
+        errors.append(f"unexpected QEMU domain matrix: {arm_domain_expression!r}")
+    contract = job_section(workflow, "test-contract")
+    if "domains: ${{ steps.domains.outputs.domains }}" not in contract:
+        errors.append("test-contract does not expose the domain matrix output")
+    if "id: domains" not in contract:
+        errors.append("test-contract does not export the domain matrix")
     hosted_name = (
         "    name: ${{ matrix.domain.name }} "
         "(${{ matrix.platform.id }}, Python "
@@ -355,24 +383,13 @@ class TestInventoryContract(unittest.TestCase):
         self.assertEqual(set(), missing)
         self.assertEqual({}, duplicates)
         self.assertEqual(set(), unexpected)
-        self.assertEqual(25, len(product_test_modules()))
+        self.assertEqual(SHARDS, shards_for_test_root())
+        self.assertTrue(all(not shard.modules for shard in DOMAIN_DEFINITIONS))
         self.assertEqual(product_test_modules(), set(owned_modules()))
 
     def test_missing_assignment_is_rejected(self) -> None:
         missing, duplicates, unexpected = inventory_problems(SHARDS[:-1])
-        self.assertEqual(
-            {
-                "test.fitness.test_score_zero",
-                "test.fitness.test_years",
-                "test.hello.test_profile",
-                "test.jwxt.test_calendar_api",
-                "test.jwxt.test_calendar_week",
-                "test.jwxt.test_school_course_headers",
-                "test.schedule.test_lesson",
-                "test.schedule.test_schedule",
-            },
-            missing,
-        )
+        self.assertEqual(set(SHARDS[-1].modules), missing)
         self.assertEqual({}, duplicates)
         self.assertEqual(set(), unexpected)
 
@@ -380,8 +397,9 @@ class TestInventoryContract(unittest.TestCase):
         duplicate = Shard("duplicate", "Duplicate", SHARDS[0].modules)
         missing, duplicates, unexpected = inventory_problems(SHARDS + (duplicate,))
         self.assertEqual(set(), missing)
+        module = SHARDS[0].modules[0]
         self.assertEqual(
-            ["ai", "duplicate"], duplicates["test.ai_assistant.test_ai_core"]
+            ["ai", "duplicate"], duplicates[module]
         )
         self.assertEqual(set(), unexpected)
 
@@ -407,6 +425,361 @@ class TestInventoryContract(unittest.TestCase):
                 module_name(test_root / "feature/ci/test_nested.py", test_root),
             )
 
+    def test_marker_scan_is_ast_only_and_does_not_import_modules(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            test_root = Path(temporary_directory) / "test"
+            module_path = test_root / "explosive.py"
+            module_path.parent.mkdir(parents=True)
+            module_path.write_text(
+                'TEST_DOMAIN = "ai"\n'
+                "TEST_REGRESSION = True\n"
+                'raise RuntimeError("must not import")\n',
+                encoding="utf-8",
+            )
+
+            records = scan_test_modules(test_root)
+
+            self.assertEqual(1, len(records))
+            self.assertEqual("test.explosive", records[0].module)
+            self.assertEqual(("ai",), records[0].marker_values)
+            self.assertEqual((True,), records[0].regression_values)
+            self.assertEqual(
+                ("test.explosive",), shards_for_test_root(test_root)[0].modules
+            )
+            self.assertEqual(
+                ("test.explosive",),
+                regression_modules_for_test_root(test_root),
+            )
+
+    def test_nested_marker_writes_are_rejected(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            repository_root = Path(temporary_directory)
+            test_root = repository_root / "test"
+            path = test_root / "nested_marker.py"
+            path.parent.mkdir(parents=True)
+            path.write_text(
+                "# TEST_DOMAIN = 'ai'\n"
+                "text = 'TEST_DOMAIN = \\\"ai\\\"'\n"
+                "def configure():\n"
+                "    TEST_DOMAIN = 'ai'\n"
+                "if False:\n"
+                "    TEST_DOMAIN = 'ai'\n",
+                encoding="utf-8",
+            )
+
+            records = scan_test_modules(test_root)
+            errors = contract_errors(
+                repository_root=repository_root,
+                shards=shards_for_test_root(test_root),
+            )
+
+            self.assertEqual((None,), records[0].marker_values)
+            self.assertIn(
+                "TEST_DOMAIN must be a string: test.nested_marker (got None)",
+                errors,
+            )
+
+    def test_malformed_markers_are_rejected_without_evaluation(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            repository_root = Path(temporary_directory)
+            test_root = repository_root / "test"
+            sources = {
+                "duplicate.py": 'TEST_DOMAIN = "ai"\nTEST_DOMAIN = "ai"\n',
+                "unknown.py": 'TEST_DOMAIN = "future"\n',
+                "invalid.py": 'TEST_DOMAIN = "bad_domain"\n',
+                "non_string.py": "TEST_DOMAIN = 123\n",
+                "dynamic.py": 'domain = "ai"\nTEST_DOMAIN = domain\n',
+            }
+            for relative, source in sources.items():
+                path = test_root / relative
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(source, encoding="utf-8")
+
+            errors = contract_errors(
+                repository_root=repository_root,
+                shards=shards_for_test_root(test_root),
+            )
+
+            self.assertIn("duplicate TEST_DOMAIN marker: test.duplicate", errors)
+            self.assertIn("unknown TEST_DOMAIN domain: test.unknown (future)", errors)
+            self.assertIn(
+                "invalid TEST_DOMAIN marker: test.invalid ('bad_domain')", errors
+            )
+            self.assertIn(
+                "TEST_DOMAIN must be a string: test.non_string (got 123)", errors
+            )
+            self.assertIn(
+                "TEST_DOMAIN must be a string: test.dynamic (got None)", errors
+            )
+
+    def test_malformed_regression_markers_are_rejected_without_evaluation(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            repository_root = Path(temporary_directory)
+            test_root = repository_root / "test"
+            sources = {
+                "duplicate.py": (
+                    'TEST_DOMAIN = "ai"\n'
+                    "TEST_REGRESSION = True\n"
+                    "TEST_REGRESSION = True\n"
+                ),
+                "non_boolean.py": (
+                    'TEST_DOMAIN = "ai"\nTEST_REGRESSION = "yes"\n'
+                ),
+                "dynamic.py": (
+                    'TEST_DOMAIN = "ai"\nvalue = True\nTEST_REGRESSION = value\n'
+                ),
+                "chained.py": (
+                    'TEST_DOMAIN = "ai"\nTEST_REGRESSION = other = True\n'
+                ),
+                "false.py": 'TEST_DOMAIN = "ai"\nTEST_REGRESSION = False\n',
+            }
+            for relative, source in sources.items():
+                path = test_root / relative
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(source, encoding="utf-8")
+
+            records = scan_test_modules(test_root)
+            errors = contract_errors(
+                repository_root=repository_root,
+                shards=shards_for_test_root(test_root),
+            )
+
+            self.assertIn(
+                "duplicate TEST_REGRESSION marker: test.duplicate", errors
+            )
+            self.assertIn(
+                "TEST_REGRESSION must be a boolean: test.non_boolean "
+                "(got 'yes')",
+                errors,
+            )
+            self.assertIn(
+                "TEST_REGRESSION must be a boolean: test.dynamic (got None)",
+                errors,
+            )
+            self.assertIn(
+                "TEST_REGRESSION must be a boolean: test.chained (got None)",
+                errors,
+            )
+            self.assertEqual((), regression_modules(records))
+
+    def test_chained_domain_marker_is_rejected(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            repository_root = Path(temporary_directory)
+            test_root = repository_root / "test"
+            path = test_root / "chained.py"
+            path.parent.mkdir(parents=True)
+            path.write_text('TEST_DOMAIN = other = "ai"\n', encoding="utf-8")
+
+            errors = contract_errors(
+                repository_root=repository_root,
+                shards=shards_for_test_root(test_root),
+            )
+
+            self.assertIn(
+                "TEST_DOMAIN must be a string: test.chained (got None)", errors
+            )
+
+    def test_top_level_marker_mutations_are_rejected(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            repository_root = Path(temporary_directory)
+            test_root = repository_root / "test"
+            sources = {
+                "domain_augmented.py": (
+                    'TEST_DOMAIN = "ai"\nTEST_DOMAIN += "-changed"\n'
+                ),
+                "domain_deleted.py": 'TEST_DOMAIN = "ai"\ndel TEST_DOMAIN\n',
+                "regression_augmented.py": (
+                    'TEST_DOMAIN = "ai"\n'
+                    "TEST_REGRESSION = True\n"
+                    "TEST_REGRESSION += False\n"
+                ),
+                "regression_deleted.py": (
+                    'TEST_DOMAIN = "ai"\n'
+                    "TEST_REGRESSION = True\n"
+                    "del TEST_REGRESSION\n"
+                ),
+            }
+            for relative, source in sources.items():
+                path = test_root / relative
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(source, encoding="utf-8")
+
+            errors = contract_errors(repository_root=repository_root)
+
+            self.assertIn(
+                "duplicate TEST_DOMAIN marker: test.domain_augmented", errors
+            )
+            self.assertIn(
+                "duplicate TEST_DOMAIN marker: test.domain_deleted", errors
+            )
+            self.assertIn(
+                "duplicate TEST_REGRESSION marker: test.regression_augmented",
+                errors,
+            )
+            self.assertIn(
+                "duplicate TEST_REGRESSION marker: test.regression_deleted",
+                errors,
+            )
+
+    def test_module_control_flow_cannot_mutate_markers(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            repository_root = Path(temporary_directory)
+            test_root = repository_root / "test"
+            sources = {
+                "domain_conditional.py": (
+                    'TEST_DOMAIN = "ai"\n'
+                    "if condition:\n"
+                    '    TEST_DOMAIN = "schedule"\n'
+                ),
+                "regression_conditional.py": (
+                    'TEST_DOMAIN = "ai"\n'
+                    "TEST_REGRESSION = True\n"
+                    "try:\n"
+                    "    TEST_REGRESSION = False\n"
+                    "except Exception:\n"
+                    "    pass\n"
+                ),
+            }
+            for relative, source in sources.items():
+                path = test_root / relative
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(source, encoding="utf-8")
+
+            errors = contract_errors(repository_root=repository_root)
+
+            self.assertIn(
+                "duplicate TEST_DOMAIN marker: test.domain_conditional", errors
+            )
+            self.assertIn(
+                "duplicate TEST_REGRESSION marker: test.regression_conditional",
+                errors,
+            )
+
+    def test_other_module_scope_bindings_cannot_mutate_markers(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            repository_root = Path(temporary_directory)
+            test_root = repository_root / "test"
+            mutations = {
+                "except_target": (
+                    "try:\n    pass\n"
+                    "except Exception as TEST_DOMAIN:\n    pass\n"
+                ),
+                "for_target": "for TEST_DOMAIN in ():\n    pass\n",
+                "with_target": (
+                    "with context_manager() as TEST_DOMAIN:\n    pass\n"
+                ),
+                "import_alias": "import package as TEST_DOMAIN\n",
+                "from_import_alias": "from package import value as TEST_DOMAIN\n",
+                "named_expression": "if (TEST_DOMAIN := 'schedule'):\n    pass\n",
+                "function_name": "def TEST_DOMAIN():\n    pass\n",
+                "class_name": "class TEST_DOMAIN:\n    pass\n",
+                "match_case": (
+                    "match value:\n"
+                    "    case 1:\n"
+                    '        TEST_DOMAIN = "schedule"\n'
+                ),
+                "match_capture": (
+                    "match value:\n"
+                    "    case TEST_DOMAIN:\n"
+                    "        pass\n"
+                ),
+            }
+            for name, mutation in mutations.items():
+                path = test_root / f"{name}.py"
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(
+                    'TEST_DOMAIN = "ai"\n' + mutation,
+                    encoding="utf-8",
+                )
+
+            errors = contract_errors(repository_root=repository_root)
+
+            for name in mutations:
+                with self.subTest(binding=name):
+                    self.assertIn(
+                        f"duplicate TEST_DOMAIN marker: test.{name}", errors
+                    )
+
+    def test_marker_discovery_is_sorted_and_new_files_need_no_central_edit(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            test_root = Path(temporary_directory) / "test"
+            for relative in ("z_added.py", "a_existing.py", "feature/middle.py"):
+                path = test_root / relative
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text('TEST_DOMAIN = "ai"\n', encoding="utf-8")
+
+            records = scan_test_modules(test_root)
+            shard = shards_for_test_root(test_root)[0]
+
+            self.assertEqual(
+                ("test.a_existing", "test.feature.middle", "test.z_added"),
+                tuple(record.module for record in records),
+            )
+            self.assertEqual(
+                ("test.a_existing", "test.feature.middle", "test.z_added"),
+                shard.modules,
+            )
+            self.assertEqual(
+                tuple(
+                    (definition.id, definition.name)
+                    for definition in DOMAIN_DEFINITIONS
+                ),
+                tuple(
+                    (definition.id, definition.name)
+                    for definition in shards_for_test_root(test_root)
+                ),
+            )
+
+    def test_parallel_pr_additions_compose_without_shared_inventory_edits(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            test_root = Path(temporary_directory) / "test"
+            baseline = {
+                "ai/existing.py": 'TEST_DOMAIN = "ai"\n',
+                "ui/existing.py": 'TEST_DOMAIN = "qt-ui"\n',
+                "notification/existing.py": (
+                    'TEST_DOMAIN = "notification-crawler"\n'
+                ),
+                "auth/existing.py": 'TEST_DOMAIN = "auth-session"\n',
+                "schedule/existing.py": 'TEST_DOMAIN = "schedule"\n',
+            }
+            for relative, source in baseline.items():
+                path = test_root / relative
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(source, encoding="utf-8")
+
+            first_pr = test_root / "feature_a" / "test_first.py"
+            first_pr.parent.mkdir(parents=True)
+            first_pr.write_text('TEST_DOMAIN = "ai"\n', encoding="utf-8")
+            first_inventory = shards_for_test_root(test_root)
+            self.assertIn(
+                "test.feature_a.test_first", first_inventory[0].modules
+            )
+            self.assertNotIn(
+                "test.feature_b.test_second",
+                {module for shard in first_inventory for module in shard.modules},
+            )
+
+            second_pr = test_root / "feature_b" / "test_second.py"
+            second_pr.parent.mkdir(parents=True)
+            second_pr.write_text(
+                'TEST_DOMAIN = "schedule"\nTEST_REGRESSION = True\n',
+                encoding="utf-8",
+            )
+            merged_inventory = shards_for_test_root(test_root)
+
+            self.assertIn("test.feature_a.test_first", merged_inventory[0].modules)
+            self.assertIn(
+                "test.feature_b.test_second", merged_inventory[-1].modules
+            )
+            self.assertEqual(
+                ("test.feature_b.test_second",),
+                regression_modules_for_test_root(test_root),
+            )
+            self.assertEqual(
+                [],
+                contract_errors(repository_root=test_root.parent),
+            )
+
     def test_added_product_module_is_missing(self) -> None:
         product_modules = product_test_modules() | {"test.new_product_test"}
         missing, duplicates, unexpected = inventory_problems(
@@ -417,13 +790,14 @@ class TestInventoryContract(unittest.TestCase):
         self.assertEqual(set(), unexpected)
 
     def test_deleted_product_module_makes_declaration_unexpected(self) -> None:
-        product_modules = product_test_modules() - {"test.schedule.test_schedule"}
+        removed_module = sorted(product_test_modules())[0]
+        product_modules = product_test_modules() - {removed_module}
         missing, duplicates, unexpected = inventory_problems(
             product_modules=product_modules
         )
         self.assertEqual(set(), missing)
         self.assertEqual({}, duplicates)
-        self.assertEqual({"test.schedule.test_schedule"}, unexpected)
+        self.assertEqual({removed_module}, unexpected)
 
     def test_existing_non_product_module_is_unexpected(self) -> None:
         shards = SHARDS + (
@@ -468,10 +842,38 @@ class TestInventoryContract(unittest.TestCase):
     def test_declared_modules_exist_and_parse(self) -> None:
         self.assertEqual([], contract_errors())
 
+    def test_contract_uses_marker_inventory_for_an_isolated_root(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            repository_root = Path(temporary_directory)
+            path = repository_root / "test" / "only.py"
+            path.parent.mkdir(parents=True)
+            path.write_text('TEST_DOMAIN = "ai"\n', encoding="utf-8")
+
+            errors = contract_errors(repository_root=repository_root)
+
+            self.assertIn("empty domain: qt-ui", errors)
+            self.assertNotIn("missing test module: test.only", errors)
+
+    def test_contract_rejects_an_empty_regression_inventory(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            repository_root = Path(temporary_directory)
+            test_root = repository_root / "test"
+            for domain in DOMAIN_DEFINITIONS:
+                path = test_root / domain.id / "test_existing.py"
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(
+                    f'TEST_DOMAIN = "{domain.id}"\n', encoding="utf-8"
+                )
+
+            errors = contract_errors(repository_root=repository_root)
+
+            self.assertIn("no regression test modules are marked", errors)
+
     def test_regressions_are_unique_and_owned(self) -> None:
-        self.assertEqual(6, len(REGRESSION_MODULES))
-        self.assertEqual(6, len(set(REGRESSION_MODULES)))
-        self.assertLessEqual(set(REGRESSION_MODULES), set(owned_modules()))
+        modules = regression_modules()
+        self.assertTrue(modules)
+        self.assertEqual(len(modules), len(set(modules)))
+        self.assertLessEqual(set(modules), set(owned_modules()))
 
     def test_contract_cli_succeeds(self) -> None:
         result = subprocess.run(
@@ -486,7 +888,78 @@ class TestInventoryContract(unittest.TestCase):
             check=False,
         )
         self.assertEqual(0, result.returncode, result.stderr)
-        self.assertIn("25 product test modules", result.stdout)
+        self.assertIn(
+            f"{len(product_test_modules())} product test modules",
+            result.stdout,
+        )
+
+    def test_contract_cli_markdown_uses_runtime_inventory(self) -> None:
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "test.ci.check_test_contract",
+                "--format",
+                "markdown",
+            ],
+            cwd=REPOSITORY_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual(render_inventory_markdown().strip(), result.stdout.strip())
+
+    def test_domain_json_uses_the_single_validated_definition(self) -> None:
+        payload = json.loads(render_domain_matrix_json())
+
+        self.assertEqual(
+            [
+                {"id": definition.id, "name": definition.name}
+                for definition in DOMAIN_DEFINITIONS
+            ],
+            payload,
+        )
+
+    def test_contract_cli_domain_json_is_machine_readable(self) -> None:
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "test.ci.check_test_contract",
+                "--format",
+                "domain-json",
+            ],
+            cwd=REPOSITORY_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual(json.loads(render_domain_matrix_json()), json.loads(result.stdout))
+
+    def test_markdown_renderer_rescans_the_requested_test_root(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            test_root = Path(temporary_directory) / "test"
+            for domain in DOMAIN_DEFINITIONS:
+                path = test_root / domain.id / "test_existing.py"
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(
+                    f'TEST_DOMAIN = "{domain.id}"\n', encoding="utf-8"
+                )
+            added = test_root / "feature" / "test_added.py"
+            added.parent.mkdir(parents=True)
+            added.write_text(
+                'TEST_DOMAIN = "ai"\nTEST_REGRESSION = True\n',
+                encoding="utf-8",
+            )
+
+            markdown = render_inventory_markdown(test_root=test_root)
+
+            self.assertIn("6 product test modules", markdown)
+            self.assertIn("`test.feature.test_added`", markdown)
+            self.assertIn("### Regression modules", markdown)
 
 
 class TestShardRunner(unittest.TestCase):
@@ -569,10 +1042,56 @@ class TestShardRunner(unittest.TestCase):
         hard_exit.assert_not_called()
 
 
+class TestRegressionRunner(unittest.TestCase):
+    @patch("test.ci.run_test_regressions.regression_modules", return_value=())
+    def test_empty_regression_inventory_is_rejected(self, _modules) -> None:
+        with self.assertRaisesRegex(
+            ValueError, "no regression test modules are marked"
+        ):
+            build_regression_suite()
+
+    @patch("test.ci.run_test_regressions.unittest.defaultTestLoader.loadTestsFromName")
+    @patch(
+        "test.ci.run_test_regressions.regression_modules",
+        return_value=("test.first", "test.second"),
+    )
+    def test_suite_loads_only_ast_derived_modules(self, _modules, load_tests) -> None:
+        load_tests.side_effect = lambda module: unittest.FunctionTestCase(
+            lambda: None, description=module
+        )
+
+        suite = build_regression_suite()
+
+        self.assertEqual(2, suite.countTestCases())
+        self.assertEqual(
+            [call("test.first"), call("test.second")], load_tests.call_args_list
+        )
+
+    def test_failure_and_normal_success_return_without_hard_exit(self) -> None:
+        result = Mock()
+        with patch.object(run_test_regressions.os, "_exit") as hard_exit:
+            result.wasSuccessful.return_value = True
+            self.assertEqual(
+                0,
+                finish_regression_result(
+                    result, hard_exit_on_success=False
+                ),
+            )
+            result.wasSuccessful.return_value = False
+            self.assertEqual(
+                1,
+                finish_regression_result(
+                    result, hard_exit_on_success=True
+                ),
+            )
+        hard_exit.assert_not_called()
+
+
 class TestWorkflowContract(unittest.TestCase):
     def test_paths_exist(self) -> None:
         self.assertTrue(WORKFLOW_PATH.is_file())
         self.assertTrue(TESTING_DOC_PATH.is_file())
+        self.assertTrue(NOTIFICATION_DOC_PATH.is_file())
         self.assertTrue(PR_TEMPLATE_PATH.is_file())
 
     def test_triggers_permissions_and_concurrency_are_bounded(self) -> None:
@@ -585,7 +1104,7 @@ class TestWorkflowContract(unittest.TestCase):
         self.assertIn("cancel-in-progress: true", workflow)
         self.assertNotIn("contents: write", workflow)
 
-    def test_hosted_matrix_has_five_platforms_and_five_domains(self) -> None:
+    def test_hosted_matrix_has_static_platforms_and_dynamic_domains(self) -> None:
         section = job_section(
             WORKFLOW_PATH.read_text(encoding="utf-8"), "test-shards"
         )
@@ -597,8 +1116,12 @@ class TestWorkflowContract(unittest.TestCase):
                 self.assertIn(f"os: {runner}", section)
                 self.assertIn(f'python-version: "{python_version}"', section)
                 self.assertIn(f"machine: {machine}", section)
-        for shard in SHARDS:
-            self.assertEqual(1, section.count(f"- id: {shard.id}\n"))
+        self.assertEqual(
+            DOMAIN_MATRIX_EXPRESSION,
+            matrix_axis_expression(
+                WORKFLOW_PATH.read_text(encoding="utf-8"), "test-shards", "domain"
+            ),
+        )
         self.assertIn("uv sync --frozen --group dev", section)
         self.assertIn("--expected-machine ${{ matrix.platform.machine }}", section)
 
@@ -669,26 +1192,31 @@ class TestWorkflowContract(unittest.TestCase):
     def test_matrix_contract_rejects_member_and_job_mutations(self) -> None:
         workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
         extra_platform = workflow.replace(
-            "        domain:\n",
+            f"        domain: {DOMAIN_MATRIX_EXPRESSION}\n",
             "          - id: linux-extra-py312\n"
             "            os: ubuntu-22.04\n"
             '            python-version: "3.12"\n'
             "            machine: x86_64\n"
-            "        domain:\n",
+            f"        domain: {DOMAIN_MATRIX_EXPRESSION}\n",
             1,
         )
         missing_hosted_domain = workflow.replace(
-            "          - id: schedule\n            name: Schedule\n",
-            "",
+            f"        domain: {DOMAIN_MATRIX_EXPRESSION}\n",
+            "        domain: []\n",
             1,
         )
         arm_marker = "  linux-arm-shards:"
-        prefix, arm_and_after = workflow.split(arm_marker, 1)
-        duplicate_arm_domain = prefix + arm_marker + arm_and_after.replace(
-            "          - id: ai\n            name: AI core and features\n",
-            "          - id: ai\n            name: AI core and features\n"
-            "          - id: ai\n            name: AI core and features\n",
+        prefix, arm_section = workflow.split(arm_marker, 1)
+        broken_arm_domain = prefix + arm_marker + arm_section.replace(
+            f"        domain: {DOMAIN_MATRIX_EXPRESSION}\n",
+            "        domain: ${{ fromJSON(needs.other.outputs.domains) }}\n",
             1,
+        )
+        self.assertEqual(
+            "${{ fromJSON(needs.other.outputs.domains) }}",
+            matrix_axis_expression(
+                broken_arm_domain, "linux-arm-shards", "domain"
+            ),
         )
         extra_job = workflow.replace(
             "  ci-gate:\n",
@@ -702,13 +1230,13 @@ class TestWorkflowContract(unittest.TestCase):
         for label, mutation in (
             ("extra-platform", extra_platform),
             ("missing-hosted-domain", missing_hosted_domain),
-            ("duplicate-arm-domain", duplicate_arm_domain),
+            ("broken-arm-domain", broken_arm_domain),
             ("extra-job", extra_job),
         ):
             with self.subTest(mutation=label):
                 self.assertTrue(matrix_contract_errors(mutation))
 
-    def test_arm_matrix_has_five_domains_and_complete_qt_runtime(self) -> None:
+    def test_arm_matrix_has_dynamic_domains_and_complete_qt_runtime(self) -> None:
         workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
         section = job_section(workflow, "linux-arm-shards")
         self.assertIn("needs: test-contract", section)
@@ -722,8 +1250,14 @@ class TestWorkflowContract(unittest.TestCase):
         self.assertIn("--system-site-packages", section)
         self.assertIn("uv sync --frozen --group dev", section)
         self.assertNotIn("rm -f uv.lock", section)
-        for shard in SHARDS:
-            self.assertEqual(1, section.count(f"- id: {shard.id}\n"))
+        self.assertEqual(
+            DOMAIN_MATRIX_EXPRESSION,
+            matrix_axis_expression(
+                WORKFLOW_PATH.read_text(encoding="utf-8"),
+                "linux-arm-shards",
+                "domain",
+            ),
+        )
         for import_name in ARM_IMPORTS:
             self.assertIn(f"--require-import {import_name}", section)
         for pin in ARM_PINS:
@@ -757,14 +1291,18 @@ class TestWorkflowContract(unittest.TestCase):
             arm_hard_exit_contract_errors(duplicate),
         )
 
-    def test_regression_job_runs_the_registered_modules(self) -> None:
+    def test_regression_job_uses_the_dynamic_runner(self) -> None:
         section = job_section(
             WORKFLOW_PATH.read_text(encoding="utf-8"),
             "existing-bug-regressions",
         )
         self.assertIn("needs: test-contract", section)
-        for module in REGRESSION_MODULES:
-            self.assertEqual(1, section.count(module))
+        self.assertEqual(
+            1,
+            section.count("python -m test.ci.run_test_regressions"),
+        )
+        for module in regression_modules():
+            self.assertNotIn(module, section)
 
     def test_gate_needs_every_required_job(self) -> None:
         section = job_section(
@@ -807,16 +1345,28 @@ class TestWorkflowContract(unittest.TestCase):
 
     def test_documentation_matches_matrix_and_rerun_policy(self) -> None:
         documentation = TESTING_DOC_PATH.read_text(encoding="utf-8")
+        self.assertIn("--domain <domain-id>", documentation)
+        self.assertIn("python -m unittest <module> -v", documentation)
         for shard in SHARDS:
-            self.assertIn(f"--domain {shard.id}", documentation)
-            self.assertIn(shard.name, documentation)
             for module in shard.modules:
-                self.assertIn(module, documentation)
+                self.assertNotIn(module, documentation)
+        self.assertIn("稳定的域 ID、Actions 显示名和矩阵顺序", documentation)
+        self.assertIn("--format markdown", documentation)
         for platform_id, runner, _python_version, _machine in HOSTED_PLATFORMS:
             self.assertIn(platform_id, documentation)
             self.assertIn(runner.replace("windows-latest", "Windows latest").replace("macos-latest", "macOS latest").replace("macos-15-intel", "macOS 15 Intel").replace("ubuntu-22.04", "Ubuntu 22.04"), documentation)
         for phrase in (
             "uv run --frozen local_test.py",
+            "test/ci/shards.py",
+            "TEST_DOMAIN = \"qt-ui\"",
+            "TEST_REGRESSION = True",
+            "python -m test.ci.run_test_regressions",
+            "check_test_contract --format markdown",
+            "不需要修改共享分片清单、workflow 命令",
+            "各自新增测试时只修改自己的测试文件",
+            "新增域只需修改唯一的稳定域定义",
+            "在途分支 rebase 后",
+            "合同检查器通过 AST 扫描",
             "test/ci/**",
             "test/feature/ci/test_case.py",
             "每个产品测试模块恰好属于一个主测试域",
@@ -824,8 +1374,8 @@ class TestWorkflowContract(unittest.TestCase):
             "本地用例数和耗时不能代替",
             "linux-arm64-qemu-py310",
             "<domain display name> (<platform id>, Python <version>)",
-            "30 个分片",
-            "33 个 checks",
+            "各平台 × 当前域定义的分片",
+            "矩阵与 check 数会自动随之变化",
             "QEMU 结果是兼容",
             "synchronize",
             "workflow_dispatch",
@@ -833,6 +1383,13 @@ class TestWorkflowContract(unittest.TestCase):
             "PR 测试成功不能替代构建成功",
         ):
             self.assertIn(phrase, documentation)
+
+    def test_notification_documentation_uses_dynamic_regression_inventory(self) -> None:
+        documentation = NOTIFICATION_DOC_PATH.read_text(encoding="utf-8")
+        self.assertIn("python -m test.ci.run_test_regressions", documentation)
+        self.assertIn("TEST_REGRESSION = True", documentation)
+        for module in product_test_modules():
+            self.assertNotIn(module, documentation)
 
     def test_pr_template_requests_test_evidence_without_credentials(self) -> None:
         template = PR_TEMPLATE_PATH.read_text(encoding="utf-8")

--- a/test/fitness/test_score_zero.py
+++ b/test/fitness/test_score_zero.py
@@ -2,6 +2,8 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import Mock
 
+TEST_DOMAIN = "schedule"
+
 from auth import ServerError
 from fitness.score import Fitness, _json
 

--- a/test/fitness/test_session.py
+++ b/test/fitness/test_session.py
@@ -13,6 +13,8 @@ from auth import ServerError
 from auth.constant import FITNESS_LOGIN_URL
 from app.sessions.fitness_session import FitnessSession
 
+TEST_DOMAIN = "auth-session"
+
 
 FITNESS_AES_KEY = b"Wet2C8d34f62ndi3"
 FITNESS_AES_IV = b"K6iv85jBD8jgf32D"

--- a/test/fitness/test_years.py
+++ b/test/fitness/test_years.py
@@ -3,6 +3,8 @@ from datetime import date
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
+TEST_DOMAIN = "schedule"
+
 from auth import ServerError
 from fitness.score import Fitness
 

--- a/test/hello/test_profile.py
+++ b/test/hello/test_profile.py
@@ -7,6 +7,8 @@ import requests
 from auth import ServerError
 from hello.profile import HelloProfile
 
+TEST_DOMAIN = "schedule"
+
 
 def _student(**overrides):
     student = {

--- a/test/hello/test_session.py
+++ b/test/hello/test_session.py
@@ -19,6 +19,8 @@ from app.sessions.hello_session import (
 from app.sessions.session_backend import AccessMode, SessionBackend
 from app.utils.session_manager import SessionManager
 
+TEST_DOMAIN = "auth-session"
+
 
 DEFAULT_SYSTEM_TYPE = "yingxin_student_pc"
 

--- a/test/jwxt/test_calendar_api.py
+++ b/test/jwxt/test_calendar_api.py
@@ -7,6 +7,8 @@ import requests
 from auth import ServerError
 from jwxt.calendar import SchoolCalendar
 
+TEST_DOMAIN = "schedule"
+
 
 def _response(payload=None, *, error=None):
     return SimpleNamespace(

--- a/test/jwxt/test_calendar_week.py
+++ b/test/jwxt/test_calendar_week.py
@@ -4,6 +4,8 @@ from unittest.mock import patch
 
 from jwxt.calendar import CalendarTerm
 
+TEST_DOMAIN = "schedule"
+
 
 def _term(**overrides) -> CalendarTerm:
     data = {

--- a/test/jwxt/test_school_course_headers.py
+++ b/test/jwxt/test_school_course_headers.py
@@ -5,6 +5,8 @@ from unittest.mock import Mock
 
 from jwxt.school_course import SchoolCourseQuery
 
+TEST_DOMAIN = "schedule"
+
 
 class SchoolCourseHeadersTest(unittest.TestCase):
     def test_departments_sends_kcbcx_referer(self):

--- a/test/library/test_booking_parse.py
+++ b/test/library/test_booking_parse.py
@@ -2,6 +2,8 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import patch
 
+TEST_DOMAIN = "qt-ui"
+
 from library.seats import ACTION_LABELS, BASE_URL, Library, MyBooking
 
 

--- a/test/notification/test_notification_sources.py
+++ b/test/notification/test_notification_sources.py
@@ -19,6 +19,9 @@ from notification.crawlers.generic import (
 )
 from notification.source import SourceRegistry, source_registry
 
+TEST_DOMAIN = "notification-crawler"
+TEST_REGRESSION = True
+
 
 class DateParserTest(unittest.TestCase):
     def test_supported_date_variants(self):

--- a/test/schedule/test_lesson.py
+++ b/test/schedule/test_lesson.py
@@ -3,6 +3,9 @@ import unittest
 from schedule import Lesson
 from schedule.lesson import _lesson_object_hook
 
+TEST_DOMAIN = "schedule"
+TEST_REGRESSION = True
+
 
 class TestLesson(unittest.TestCase):
     def test_serialize(self):

--- a/test/schedule/test_schedule.py
+++ b/test/schedule/test_schedule.py
@@ -1,6 +1,8 @@
 import unittest
 from schedule import WeekSchedule, DaySchedule, Schedule, Lesson
 
+TEST_DOMAIN = "schedule"
+
 
 class TestSchedule(unittest.TestCase):
     def setUp(self):

--- a/test/sessions/session_manager.py
+++ b/test/sessions/session_manager.py
@@ -14,6 +14,8 @@ from app.utils.session_manager import SessionManager
 import app.utils.session_manager as session_manager_module
 from app.utils.session_persistence import SiteSnapshot
 
+TEST_DOMAIN = "auth-session"
+
 
 class NormalTestSession(CommonLoginSession):
     """用于验证普通访问模式创建逻辑的测试 Session。"""

--- a/test/test_crawler_challenge.py
+++ b/test/test_crawler_challenge.py
@@ -8,6 +8,9 @@ import requests
 
 from notification.crawlers import crawler
 
+TEST_DOMAIN = "notification-crawler"
+TEST_REGRESSION = True
+
 
 NEW_CHALLENGE_HTML = """
 <html>


### PR DESCRIPTION
## 变更内容

- 通过产品测试文件顶层的 `TEST_DOMAIN` 标记自动生成 PR 测试分片，新增测试文件无需修改共享清单
- 通过 `TEST_REGRESSION = True` 标记自动发现历史回归重跑目标，保留至少 6 个回归模块的合同下限
- 合同检查器使用 AST 校验 marker，拒绝动态/重复/嵌套控制流绑定以及 `global`/`nonlocal` marker 声明
- 默认导入时只扫描测试树一次，并复用扫描结果生成域分片与回归清单
- workflow 从合同检查结果导出域矩阵；命令失败会直接使导出步骤失败，避免错误延迟到下游矩阵
- 删除回归 runner 重复的空清单检查，补充并行 PR、回归下限、作用域绑定和 workflow 失败传播测试
- 更新通知开发文档：回归命令统一使用动态发现集合，并明确旧文档命令集合的调整

## 背景

此前新增测试需要同时修改共享分片清单、workflow 命令、模块数量和文档；多个 PR 并行新增测试时容易产生冲突。现在向现有测试域新增独立测试文件时，只需在文件顶层声明 `TEST_DOMAIN`；如需加入历史回归重跑，再声明 `TEST_REGRESSION = True`，无需同步维护共享模块列表。

该机制消除的是独立新增测试文件对共享清单的竞争；新增测试域、修改同一测试文件，或有意降低回归保护下限时，仍按普通 Git 流程处理。

## 行为变更说明

`docs/development/notification.md` 的回归命令现在与 CI 中的 marker 集合保持一致，由 `python -m test.ci.run_test_regressions` 动态运行。此前文档命令额外包含的 `test_ai_core`、`test_ctrl_c`、`test_qrcode_login` 不再由该入口单独运行；`test_notice_thread`、`test_schedule_lesson` 纳入统一入口。当前数量和完整列表可通过 `python -m test.ci.check_test_contract --format markdown` 查看。

## 验证

- `python -m unittest -q test.ci.test_pr_workflow`（62 项通过）
- `python -m test.ci.check_test_contract`（25 个测试模块、5 个域）
- `python -m test.ci.check_test_contract --format markdown`
- `python -m compileall -q test/ci`
- `git diff --check`

本地未运行完整产品测试矩阵；PR 的 Actions 矩阵在旧 head 上 33/33 通过。更新 head 后请以新的 CI 矩阵结果为准。
